### PR TITLE
Added unsafe utility to inject HTML

### DIFF
--- a/src/tdom/__init__.py
+++ b/src/tdom/__init__.py
@@ -1,6 +1,6 @@
 from .utils import _Attribute, _Comment, _parse
 from .dom import COMMENT, DOCUMENT_TYPE, TEXT, ELEMENT, FRAGMENT
-from .dom import Node, Comment, DocumentType, Text, Element, Fragment, parse, _clone
+from .dom import Node, Comment, DocumentType, Text, Element, Fragment, parse, unsafe, _clone
 
 
 _parsed = {}
@@ -72,7 +72,7 @@ svg = _util(True)
 
 
 __all__ = [
-  'render', 'html', 'svg', 'parse',
+  'render', 'html', 'svg', 'parse', 'unsafe',
   'Node', 'Comment', 'DocumentType', 'Text', 'Element', 'Fragment',
   'COMMENT', 'DOCUMENT_TYPE', 'TEXT', 'ELEMENT', 'FRAGMENT',
 ]

--- a/src/tdom/dom.py
+++ b/src/tdom/dom.py
@@ -10,6 +10,7 @@ _prefix = 't🐍' + str(random())[2:5]
 _data = f'<!--{_prefix}-->'
 
 
+
 ELEMENT = 1
 # ATTRIBUTE = 2
 TEXT = 3
@@ -91,7 +92,8 @@ class Text(Node):
     super().__init__(data=data)
 
   def __str__(self):
-    return escape(str(self['data']))
+    data = self['data']
+    return data if isinstance(data, Unsafe) else escape(str(data))
 
 
 class Element(Node):
@@ -185,6 +187,12 @@ if _IS_MICRO_PYTHON:
   ATTRIBUTES = re.compile(r'([^\s=]+)(=(([\'"])[\s\S]*?\4|\S+))?')
   NAME_CHAR = re.compile(r'[^/>\s]')
 
+
+  class Unsafe(str):
+    def __init__(self, *args, **kwargs):
+      super().__init__(*args, **kwargs)
+
+
   def _attributes(props, attrs):
     while match := ATTRIBUTES.match(attrs.strip()):
       key = match.group(1)
@@ -267,6 +275,12 @@ if _IS_MICRO_PYTHON:
 else:
   from html.parser import HTMLParser
 
+
+  class Unsafe(str):
+    def __new__(cls, value, *args, **kwargs):   
+      return super(Unsafe, cls).__new__(cls, value)
+
+
   class DOMParser(HTMLParser):
     def __init__(self, xml=False):
       super().__init__()
@@ -319,3 +333,7 @@ else:
     parser = DOMParser(xml)
     parser.feed(content)
     return parser.node
+
+
+def unsafe(value):
+  return Unsafe(value)

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -1,6 +1,6 @@
 """Cover the examples in Andrea's demo."""
 
-from tdom import html, svg
+from tdom import html, svg, unsafe
 
 
 def test_automatic_quotes():
@@ -73,6 +73,12 @@ def test_style():
     style = {"color": "red", "font-size": "12px"}
     result = html(t"<div style={style} />")
     assert str(result) == '<div style="color:red;font-size:12px"></div>'
+
+
+def test_unsafe():
+    """Unsafe strings."""
+    result = html(t"<div>{unsafe('<hr>')}</div>")
+    assert str(result) == '<div><hr></div>'
 
 
 def test_component():


### PR DESCRIPTION
This MR would like to address the use case of injecting raw *HTML* (hence unsafe) as part of an interpolation within an element/fragment node.