### PR TITLE
Add comments that will be ignored in the tree

### DIFF
--- a/src/tdom/dom.py
+++ b/src/tdom/dom.py
@@ -236,7 +236,9 @@ if _IS_MICRO_PYTHON:
           _text(node, content, ts, te)
           if content[i+1:i+3] == '--':
             j = content.index('-->', i + 3)
-            _append(node, Comment(content[i+3:j]))
+            data = content[i+3:j]
+            if not (data.startswith('#') and data.endswith('#')):
+              _append(node, Comment(data))
             i = j + 3
           else:
             j = content.index('>', i + 1)
@@ -329,7 +331,7 @@ else:
     def handle_comment(self, data):
       if data == '/':
         self.handle_endtag(self.node['name'])
-      else:
+      elif not (data.startswith('#') and data.endswith('#')):
         _append(self.node, Comment(data))
 
     def handle_decl(self, data):

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -60,6 +60,12 @@ def test_void_siblings():
     assert str(result) == "<p></p><hr><p></p>"
 
 
+def test_dev_comments():
+    """Developer comments."""
+    result = html(t"<!--#1--><!--#2#--><!--##--><!--3#-->")
+    assert str(result) == "<!--#1--><!--3#-->"
+
+
 def test_svg():
     """preseved XML/SVG self closing nature."""
     result = html(


### PR DESCRIPTION
This MR allows developers to add comments within the template code without polluting the final output with those comments:

```html
<!--# this comment won't exist live #-->
<!-- but this one will -->
<!--# ... or this one -->
<!-- or this one ... #-->
```