### PR TITLE
Fix #12 - Allow raw templates as interpolated values

### DIFF
--- a/src/tdom/__init__.py
+++ b/src/tdom/__init__.py
@@ -15,6 +15,7 @@ try:
 except ImportError:
   pass
 
+
 def _util(svg):
   def fn(t):
     if not isinstance(t, Template):
@@ -22,7 +23,7 @@ def _util(svg):
 
     strings = t.strings
 
-    values = [entry.value for entry in t.interpolations]
+    values = [_resolve(fn, entry) for entry in t.interpolations]
 
     length = len(values)
 
@@ -60,6 +61,11 @@ def _util(svg):
     return node
 
   return fn
+
+
+def _resolve(fn, entry):
+  value = entry.value
+  return fn(value) if isinstance(value, Template) else value
 
 
 def render(where, what):

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -66,6 +66,13 @@ def test_dev_comments():
     assert str(result) == "<!--#1--><!--3#-->"
 
 
+def test_template_as_interpolation():
+    """Template as interpolation."""
+    inner = t'<em>World</em>'
+    result = html(t"<div>Hello {inner}</div>")
+    assert str(result) == '<div>Hello <em>World</em></div>'
+
+
 def test_svg():
     """preseved XML/SVG self closing nature."""
     result = html(


### PR DESCRIPTION
This MR allows the usage of raw templates as part of the interpolations that are resolved via either `html` or `svg`.