### PR TITLE
Support class-based components and callable signature detection

### DIFF
--- a/docs/usage/components.md
+++ b/docs/usage/components.md
@@ -61,7 +61,7 @@ If your template has children inside the component element, your component will
 receive them as `*children` positional arguments:
 
 ```python
-def Heading(*children: Node, title: str) -> Node:
+def Heading(children: Iterable[Node], title: str) -> Node:
     return html(t"<h1>{title}</h1><div>{children}</div>")
 
 result = html(t'<{Heading} title="My Title">Child</{Heading}>')
@@ -97,7 +97,7 @@ driving:
 def DefaultHeading() -> Template:
     return t"<h1>Default Heading</h1>"
 
-def Body(heading: str) -> Template:
+def Body(heading: Callable) -> Template:
     return t"<body><{heading} /></body>"
 
 result = html(t"<{Body} heading={DefaultHeading} />")

--- a/docs/usage/components.md
+++ b/docs/usage/components.md
@@ -29,8 +29,8 @@ a `Node`:
 
 <!-- invisible-code-block: python
 from string.templatelib import Template
-from tdom import html, ComponentCallable, Node
-from typing import Iterable
+from tdom import html, Node
+from typing import Callable, Iterable
 -->
 
 ```python
@@ -116,7 +116,7 @@ def DefaultHeading() -> Template:
 def OtherHeading() -> Template:
     return t"<h1>Other Heading</h1>"
 
-def Body(heading: ComponentCallable) -> Template:
+def Body(heading: Callable) -> Template:
     return html(t"<body><{heading} /></body>")
 
 result = html(t"<{Body} heading={OtherHeading}></{Body}>")
@@ -135,7 +135,7 @@ def DefaultHeading() -> Template:
 def OtherHeading() -> Template:
     return t"<h1>Other Heading</h1>"
 
-def Body(heading: ComponentCallable | None = None) -> Template:
+def Body(heading: Callable | None = None) -> Template:
     return t"<body><{heading if heading else DefaultHeading} /></body>"
 
 result = html(t"<{Body} heading={OtherHeading}></{Body}>")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "tdom"
-version = "0.1.6"
+version = "0.1.7"
 description = "A 🤘 rockin' t-string HTML templating system for Python 3.14."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/tdom/__init__.py
+++ b/tdom/__init__.py
@@ -1,13 +1,12 @@
 from markupsafe import Markup, escape
 
 from .nodes import Comment, DocumentType, Element, Fragment, Node, Text
-from .processor import ComponentCallable, html
+from .processor import html
 
 # We consider `Markup` and `escape` to be part of this module's public API
 
 __all__ = [
     "Comment",
-    "ComponentCallable",
     "DocumentType",
     "Element",
     "escape",

--- a/tdom/callables.py
+++ b/tdom/callables.py
@@ -11,10 +11,10 @@ class CallableInfo:
     id: int
     """The unique identifier of the callable (from id())."""
 
-    named_args: frozenset[str]
+    named_params: frozenset[str]
     """The names of the callable's named arguments."""
 
-    required_named_args: frozenset[str]
+    required_named_params: frozenset[str]
     """The names of the callable's required named arguments."""
 
     requires_positional: bool
@@ -29,8 +29,8 @@ class CallableInfo:
         import inspect
 
         sig = inspect.signature(c)
-        named_args = []
-        required_named_args = []
+        named_params = []
+        required_named_params = []
         requires_positional = False
         kwargs = False
 
@@ -40,26 +40,26 @@ class CallableInfo:
                     if param.default is param.empty:
                         requires_positional = True
                 case inspect.Parameter.POSITIONAL_OR_KEYWORD:
-                    named_args.append(param.name)
+                    named_params.append(param.name)
                     if param.default is param.empty:
-                        required_named_args.append(param.name)
+                        required_named_params.append(param.name)
                 case inspect.Parameter.VAR_POSITIONAL:
                     # Does this necessarily mean it requires positional args?
                     # Answer: No, but we have no way of knowing how many
-                    # positional args it *might* require, so we have to assume
-                    # it does.
+                    # positional args it *might* expect, so we have to assume
+                    # that it does.
                     requires_positional = True
                 case inspect.Parameter.KEYWORD_ONLY:
-                    named_args.append(param.name)
+                    named_params.append(param.name)
                     if param.default is param.empty:
-                        required_named_args.append(param.name)
+                        required_named_params.append(param.name)
                 case inspect.Parameter.VAR_KEYWORD:
                     kwargs = True
 
         return cls(
             id=id(c),
-            named_args=frozenset(named_args),
-            required_named_args=frozenset(required_named_args),
+            named_params=frozenset(named_params),
+            required_named_params=frozenset(required_named_params),
             requires_positional=requires_positional,
             kwargs=kwargs,
         )
@@ -67,7 +67,7 @@ class CallableInfo:
     @property
     def supports_zero_args(self) -> bool:
         """Whether the callable can be called with zero arguments."""
-        return not self.requires_positional and not self.required_named_args
+        return not self.requires_positional and not self.required_named_params
 
 
 @lru_cache(maxsize=0 if "pytest" in sys.modules else 512)

--- a/tdom/callables.py
+++ b/tdom/callables.py
@@ -1,0 +1,76 @@
+import sys
+import typing as t
+from dataclasses import dataclass
+from functools import lru_cache
+
+
+@dataclass(slots=True, frozen=True)
+class CallableInfo:
+    """Information about a callable necessary for `tdom` to safely invoke it."""
+
+    id: int
+    """The unique identifier of the callable (from id())."""
+
+    named_args: frozenset[str]
+    """The names of the callable's named arguments."""
+
+    required_named_args: frozenset[str]
+    """The names of the callable's required named arguments."""
+
+    requires_positional: bool
+    """Whether the callable requires positional-only argument values."""
+
+    kwargs: bool
+    """Whether the callable accepts **kwargs."""
+
+    @classmethod
+    def from_callable(cls, c: t.Callable) -> t.Self:
+        """Create a CallableInfo from a callable."""
+        import inspect
+
+        sig = inspect.signature(c)
+        named_args = []
+        required_named_args = []
+        requires_positional = False
+        kwargs = False
+
+        for param in sig.parameters.values():
+            match param.kind:
+                case inspect.Parameter.POSITIONAL_ONLY:
+                    if param.default is param.empty:
+                        requires_positional = True
+                case inspect.Parameter.POSITIONAL_OR_KEYWORD:
+                    named_args.append(param.name)
+                    if param.default is param.empty:
+                        required_named_args.append(param.name)
+                case inspect.Parameter.VAR_POSITIONAL:
+                    # Does this necessarily mean it requires positional args?
+                    # Answer: No, but we have no way of knowing how many
+                    # positional args it *might* require, so we have to assume
+                    # it does.
+                    requires_positional = True
+                case inspect.Parameter.KEYWORD_ONLY:
+                    named_args.append(param.name)
+                    if param.default is param.empty:
+                        required_named_args.append(param.name)
+                case inspect.Parameter.VAR_KEYWORD:
+                    kwargs = True
+
+        return cls(
+            id=id(c),
+            named_args=frozenset(named_args),
+            required_named_args=frozenset(required_named_args),
+            requires_positional=requires_positional,
+            kwargs=kwargs,
+        )
+
+    @property
+    def supports_zero_args(self) -> bool:
+        """Whether the callable can be called with zero arguments."""
+        return not self.requires_positional and not self.required_named_args
+
+
+@lru_cache(maxsize=0 if "pytest" in sys.modules else 512)
+def get_callable_info(c: t.Callable) -> CallableInfo:
+    """Get the CallableInfo for a callable, caching the result."""
+    return CallableInfo.from_callable(c)

--- a/tdom/callables_test.py
+++ b/tdom/callables_test.py
@@ -12,8 +12,8 @@ def test_zero_args() -> None:
     """Test that a callable that takes zero arguments is detected."""
     info = get_callable_info(callable_zero_args)
     assert info.id == id(callable_zero_args)
-    assert info.named_args == frozenset()
-    assert info.required_named_args == frozenset()
+    assert info.named_params == frozenset()
+    assert info.required_named_params == frozenset()
     assert not info.requires_positional
     assert not info.kwargs
     assert info.supports_zero_args
@@ -28,8 +28,8 @@ def test_positional() -> None:
     """Test that a callable that takes positional arguments is detected."""
     info = get_callable_info(callable_positional)
     assert info.id == id(callable_positional)
-    assert info.named_args == frozenset(["a", "b"])
-    assert info.required_named_args == frozenset(["a", "b"])
+    assert info.named_params == frozenset(["a", "b"])
+    assert info.required_named_params == frozenset(["a", "b"])
     assert not info.requires_positional
     assert not info.kwargs
     assert not info.supports_zero_args
@@ -44,8 +44,8 @@ def test_positional_only() -> None:
     """Test that a callable that takes positional-only arguments is detected."""
     info = get_callable_info(callable_positional_only)
     assert info.id == id(callable_positional_only)
-    assert info.named_args == frozenset(["b"])
-    assert info.required_named_args == frozenset(["b"])
+    assert info.named_params == frozenset(["b"])
+    assert info.required_named_params == frozenset(["b"])
     assert info.requires_positional
     assert not info.kwargs
     assert not info.supports_zero_args
@@ -60,8 +60,8 @@ def test_positional_only_default() -> None:
     """Test that a callable that takes positional-only arguments with defaults is detected."""
     info = get_callable_info(callable_positional_only_default)
     assert info.id == id(callable_positional_only_default)
-    assert info.named_args == frozenset(["b"])
-    assert info.required_named_args == frozenset()
+    assert info.named_params == frozenset(["b"])
+    assert info.required_named_params == frozenset()
     assert not info.requires_positional
     assert not info.kwargs
     assert info.supports_zero_args
@@ -76,8 +76,8 @@ def test_kwargs() -> None:
     """Test that a callable that takes **kwargs is detected."""
     info = get_callable_info(callable_kwargs)
     assert info.id == id(callable_kwargs)
-    assert info.named_args == frozenset()
-    assert info.required_named_args == frozenset()
+    assert info.named_params == frozenset()
+    assert info.required_named_params == frozenset()
     assert not info.requires_positional
     assert info.kwargs
     assert info.supports_zero_args
@@ -92,8 +92,8 @@ def test_mixed() -> None:
     """Test that a callable that takes a mix of argument types is detected."""
     info = get_callable_info(callable_mixed)
     assert info.id == id(callable_mixed)
-    assert info.named_args == frozenset(["b", "c"])
-    assert info.required_named_args == frozenset(["b"])
+    assert info.named_params == frozenset(["b", "c"])
+    assert info.required_named_params == frozenset(["b"])
     assert info.requires_positional
     assert info.kwargs
     assert not info.supports_zero_args
@@ -108,8 +108,8 @@ def test_positional_with_defaults() -> None:
     """Test that a callable that takes positional arguments with defaults is detected."""
     info = get_callable_info(callable_positional_with_defaults)
     assert info.id == id(callable_positional_with_defaults)
-    assert info.named_args == frozenset()
-    assert info.required_named_args == frozenset()
+    assert info.named_params == frozenset()
+    assert info.required_named_params == frozenset()
     assert not info.requires_positional
     assert not info.kwargs
     assert info.supports_zero_args
@@ -124,8 +124,8 @@ def test_keyword_only() -> None:
     """Test that a callable that takes keyword-only arguments is detected."""
     info = get_callable_info(callable_keyword_only)
     assert info.id == id(callable_keyword_only)
-    assert info.named_args == frozenset(["a", "b"])
-    assert info.required_named_args == frozenset(["a"])
+    assert info.named_params == frozenset(["a", "b"])
+    assert info.required_named_params == frozenset(["a"])
     assert not info.requires_positional
     assert not info.kwargs
     assert not info.supports_zero_args
@@ -140,8 +140,8 @@ def test_var_positional() -> None:
     """Test that a callable that takes *args is detected."""
     info = get_callable_info(callable_var_positional)
     assert info.id == id(callable_var_positional)
-    assert info.named_args == frozenset()
-    assert info.required_named_args == frozenset()
+    assert info.named_params == frozenset()
+    assert info.required_named_params == frozenset()
     assert info.requires_positional
     assert not info.kwargs
     assert not info.supports_zero_args
@@ -156,8 +156,8 @@ def test_all_types() -> None:
     """Test that a callable that takes all types of arguments is detected."""
     info = get_callable_info(callable_all_types)
     assert info.id == id(callable_all_types)
-    assert info.named_args == frozenset(["b", "c"])
-    assert info.required_named_args == frozenset(["b"])
+    assert info.named_params == frozenset(["b", "c"])
+    assert info.required_named_params == frozenset(["b"])
     assert info.requires_positional
     assert info.kwargs
     assert not info.supports_zero_args

--- a/tdom/callables_test.py
+++ b/tdom/callables_test.py
@@ -3,7 +3,7 @@ import typing as t
 from .callables import get_callable_info
 
 
-def callable_zero_args() -> None:
+def callable_zero_args() -> None:  # pragma: no cover
     """Test callable that takes zero arguments."""
     pass
 
@@ -19,7 +19,7 @@ def test_zero_args() -> None:
     assert info.supports_zero_args
 
 
-def callable_positional(a: int, b: str) -> None:
+def callable_positional(a: int, b: str) -> None:  # pragma: no cover
     """Test callable that takes positional arguments."""
     pass
 
@@ -35,7 +35,7 @@ def test_positional() -> None:
     assert not info.supports_zero_args
 
 
-def callable_positional_only(a: int, /, b: str) -> None:
+def callable_positional_only(a: int, /, b: str) -> None:  # pragma: no cover
     """Test callable that takes positional-only arguments."""
     pass
 
@@ -51,7 +51,9 @@ def test_positional_only() -> None:
     assert not info.supports_zero_args
 
 
-def callable_positional_only_default(a: int = 1, /, b: str = "b") -> None:
+def callable_positional_only_default(
+    a: int = 1, /, b: str = "b"
+) -> None:  # pragma: no cover
     """Test callable that takes positional-only arguments with defaults."""
     pass
 
@@ -67,7 +69,7 @@ def test_positional_only_default() -> None:
     assert info.supports_zero_args
 
 
-def callable_kwargs(**kwargs: t.Any) -> None:
+def callable_kwargs(**kwargs: t.Any) -> None:  # pragma: no cover
     """Test callable that takes **kwargs."""
     pass
 
@@ -83,7 +85,9 @@ def test_kwargs() -> None:
     assert info.supports_zero_args
 
 
-def callable_mixed(a: int, /, b: str, *, c: float = 1.0, **kwargs: t.Any) -> None:
+def callable_mixed(
+    a: int, /, b: str, *, c: float = 1.0, **kwargs: t.Any
+) -> None:  # pragma: no cover
     """Test callable that takes a mix of argument types."""
     pass
 
@@ -99,7 +103,9 @@ def test_mixed() -> None:
     assert not info.supports_zero_args
 
 
-def callable_positional_with_defaults(a: int = 1, b: str = "b", /) -> None:
+def callable_positional_with_defaults(
+    a: int = 1, b: str = "b", /
+) -> None:  # pragma: no cover
     """Test callable that takes positional arguments with defaults."""
     pass
 
@@ -115,7 +121,7 @@ def test_positional_with_defaults() -> None:
     assert info.supports_zero_args
 
 
-def callable_keyword_only(*, a: int, b: str = "b") -> None:
+def callable_keyword_only(*, a: int, b: str = "b") -> None:  # pragma: no cover
     """Test callable that takes keyword-only arguments."""
     pass
 
@@ -131,7 +137,7 @@ def test_keyword_only() -> None:
     assert not info.supports_zero_args
 
 
-def callable_var_positional(*args: t.Any) -> None:
+def callable_var_positional(*args: t.Any) -> None:  # pragma: no cover
     """Test callable that takes *args."""
     pass
 
@@ -147,7 +153,9 @@ def test_var_positional() -> None:
     assert not info.supports_zero_args
 
 
-def callable_all_types(a: int, /, b: str, *, c: float = 1.0, **kwargs: t.Any) -> None:
+def callable_all_types(
+    a: int, /, b: str, *, c: float = 1.0, **kwargs: t.Any
+) -> None:  # pragma: no cover
     """Test callable that takes all types of arguments."""
     pass
 

--- a/tdom/callables_test.py
+++ b/tdom/callables_test.py
@@ -1,0 +1,163 @@
+import typing as t
+
+from .callables import get_callable_info
+
+
+def callable_zero_args() -> None:
+    """Test callable that takes zero arguments."""
+    pass
+
+
+def test_zero_args() -> None:
+    """Test that a callable that takes zero arguments is detected."""
+    info = get_callable_info(callable_zero_args)
+    assert info.id == id(callable_zero_args)
+    assert info.named_args == frozenset()
+    assert info.required_named_args == frozenset()
+    assert not info.requires_positional
+    assert not info.kwargs
+    assert info.supports_zero_args
+
+
+def callable_positional(a: int, b: str) -> None:
+    """Test callable that takes positional arguments."""
+    pass
+
+
+def test_positional() -> None:
+    """Test that a callable that takes positional arguments is detected."""
+    info = get_callable_info(callable_positional)
+    assert info.id == id(callable_positional)
+    assert info.named_args == frozenset(["a", "b"])
+    assert info.required_named_args == frozenset(["a", "b"])
+    assert not info.requires_positional
+    assert not info.kwargs
+    assert not info.supports_zero_args
+
+
+def callable_positional_only(a: int, /, b: str) -> None:
+    """Test callable that takes positional-only arguments."""
+    pass
+
+
+def test_positional_only() -> None:
+    """Test that a callable that takes positional-only arguments is detected."""
+    info = get_callable_info(callable_positional_only)
+    assert info.id == id(callable_positional_only)
+    assert info.named_args == frozenset(["b"])
+    assert info.required_named_args == frozenset(["b"])
+    assert info.requires_positional
+    assert not info.kwargs
+    assert not info.supports_zero_args
+
+
+def callable_positional_only_default(a: int = 1, /, b: str = "b") -> None:
+    """Test callable that takes positional-only arguments with defaults."""
+    pass
+
+
+def test_positional_only_default() -> None:
+    """Test that a callable that takes positional-only arguments with defaults is detected."""
+    info = get_callable_info(callable_positional_only_default)
+    assert info.id == id(callable_positional_only_default)
+    assert info.named_args == frozenset(["b"])
+    assert info.required_named_args == frozenset()
+    assert not info.requires_positional
+    assert not info.kwargs
+    assert info.supports_zero_args
+
+
+def callable_kwargs(**kwargs: t.Any) -> None:
+    """Test callable that takes **kwargs."""
+    pass
+
+
+def test_kwargs() -> None:
+    """Test that a callable that takes **kwargs is detected."""
+    info = get_callable_info(callable_kwargs)
+    assert info.id == id(callable_kwargs)
+    assert info.named_args == frozenset()
+    assert info.required_named_args == frozenset()
+    assert not info.requires_positional
+    assert info.kwargs
+    assert info.supports_zero_args
+
+
+def callable_mixed(a: int, /, b: str, *, c: float = 1.0, **kwargs: t.Any) -> None:
+    """Test callable that takes a mix of argument types."""
+    pass
+
+
+def test_mixed() -> None:
+    """Test that a callable that takes a mix of argument types is detected."""
+    info = get_callable_info(callable_mixed)
+    assert info.id == id(callable_mixed)
+    assert info.named_args == frozenset(["b", "c"])
+    assert info.required_named_args == frozenset(["b"])
+    assert info.requires_positional
+    assert info.kwargs
+    assert not info.supports_zero_args
+
+
+def callable_positional_with_defaults(a: int = 1, b: str = "b", /) -> None:
+    """Test callable that takes positional arguments with defaults."""
+    pass
+
+
+def test_positional_with_defaults() -> None:
+    """Test that a callable that takes positional arguments with defaults is detected."""
+    info = get_callable_info(callable_positional_with_defaults)
+    assert info.id == id(callable_positional_with_defaults)
+    assert info.named_args == frozenset()
+    assert info.required_named_args == frozenset()
+    assert not info.requires_positional
+    assert not info.kwargs
+    assert info.supports_zero_args
+
+
+def callable_keyword_only(*, a: int, b: str = "b") -> None:
+    """Test callable that takes keyword-only arguments."""
+    pass
+
+
+def test_keyword_only() -> None:
+    """Test that a callable that takes keyword-only arguments is detected."""
+    info = get_callable_info(callable_keyword_only)
+    assert info.id == id(callable_keyword_only)
+    assert info.named_args == frozenset(["a", "b"])
+    assert info.required_named_args == frozenset(["a"])
+    assert not info.requires_positional
+    assert not info.kwargs
+    assert not info.supports_zero_args
+
+
+def callable_var_positional(*args: t.Any) -> None:
+    """Test callable that takes *args."""
+    pass
+
+
+def test_var_positional() -> None:
+    """Test that a callable that takes *args is detected."""
+    info = get_callable_info(callable_var_positional)
+    assert info.id == id(callable_var_positional)
+    assert info.named_args == frozenset()
+    assert info.required_named_args == frozenset()
+    assert info.requires_positional
+    assert not info.kwargs
+    assert not info.supports_zero_args
+
+
+def callable_all_types(a: int, /, b: str, *, c: float = 1.0, **kwargs: t.Any) -> None:
+    """Test callable that takes all types of arguments."""
+    pass
+
+
+def test_all_types() -> None:
+    """Test that a callable that takes all types of arguments is detected."""
+    info = get_callable_info(callable_all_types)
+    assert info.id == id(callable_all_types)
+    assert info.named_args == frozenset(["b", "c"])
+    assert info.required_named_args == frozenset(["b"])
+    assert info.requires_positional
+    assert info.kwargs
+    assert not info.supports_zero_args

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -96,7 +96,7 @@ def _instrument(
             yield placeholder
 
 
-@lru_cache(maxsize=0 if "pytest" in sys.modules else 256)
+@lru_cache(maxsize=0 if "pytest" in sys.modules else 512)
 def _instrument_and_parse_internal(
     strings: tuple[str, ...], callable_ids: tuple[int | None, ...]
 ) -> Node:

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -293,7 +293,7 @@ def _node_from_value(value: object) -> Node:
             return html(value)
         # Consider: falsey values, not just False and None?
         case False | None:
-            return Text("")
+            return Fragment(children=[])
         case Iterable():
             children = [_node_from_value(v) for v in value]
             return Fragment(children=children)

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -1,5 +1,6 @@
 import random
 import string
+import sys
 import typing as t
 from collections.abc import Iterable
 from functools import lru_cache
@@ -95,7 +96,7 @@ def _instrument(
             yield placeholder
 
 
-@lru_cache()
+@lru_cache(maxsize=0 if "pytest" in sys.modules else 256)
 def _instrument_and_parse_internal(
     strings: tuple[str, ...], callable_ids: tuple[int | None, ...]
 ) -> Node:

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -181,12 +181,15 @@ def _process_class_attr(value: object) -> t.Iterable[tuple[str, str | None]]:
 
 def _process_style_attr(value: object) -> t.Iterable[tuple[str, str | None]]:
     """Substitute a style attribute based on the interpolated value."""
+    if isinstance(value, str):
+        yield ("style", value)
+        return
     try:
         d = _force_dict(value, kind="style")
         style_str = "; ".join(f"{k}: {v}" for k, v in d.items())
         yield ("style", style_str)
     except TypeError:
-        yield ("style", str(value))
+        raise TypeError("'style' attribute value must be a string or dict") from None
 
 
 def _substitute_spread_attrs(

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -6,7 +6,7 @@ import pytest
 from markupsafe import Markup
 
 from .nodes import Element, Fragment, Node, Text
-from .processor import ComponentCallable, html
+from .processor import html
 
 # --------------------------------------------------------------------------
 # Basic HTML parsing tests
@@ -540,9 +540,7 @@ def test_fragment_from_component():
 
 
 def test_component_passed_as_attr_value():
-    def Wrapper(
-        *children: Node, sub_component: ComponentCallable, **attrs: t.Any
-    ) -> Template:
+    def Wrapper(*children: Node, sub_component: t.Callable, **attrs: t.Any) -> Template:
         return t"<{sub_component} {attrs}>{children}</{sub_component}>"
 
     node = html(

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -1,3 +1,4 @@
+import datetime
 import typing as t
 from dataclasses import dataclass
 from string.templatelib import Template
@@ -723,3 +724,37 @@ def test_class_component_direct_invocation():
         str(node)
         == '<div class="avatar"><a href="https://example.com/users/alice"><img src="https://example.com/alice.png" alt="Avatar of Alice" /></a><span>Alice</span></div>'
     )
+
+
+def AttributeTypeComponent(
+    data_int: int,
+    data_true: bool,
+    data_false: bool,
+    data_none: None,
+    data_float: float,
+    data_dt: datetime.datetime,
+) -> Template:
+    """Component to test that we don't incorrectly convert attribute types."""
+    assert isinstance(data_int, int)
+    assert data_true is True
+    assert data_false is False
+    assert data_none is None
+    assert isinstance(data_float, float)
+    assert isinstance(data_dt, datetime.datetime)
+    return t"Looks good!"
+
+
+def test_attribute_type_component():
+    an_int: int = 42
+    a_true: bool = True
+    a_false: bool = False
+    a_none: None = None
+    a_float: float = 3.14
+    a_dt: datetime.datetime = datetime.datetime(2024, 1, 1, 12, 0, 0)
+    node = html(
+        t"<{AttributeTypeComponent} data-int={an_int} data-true={a_true} "
+        t"data-false={a_false} data-none={a_none} data-float={a_float} "
+        t"data-dt={a_dt} />"
+    )
+    assert node == Text("Looks good!")
+    assert str(node) == "Looks good!"

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -511,7 +511,7 @@ def test_interpolated_style_attribute():
 # --------------------------------------------------------------------------
 
 
-def TemplateComponent(
+def FunctionComponent(
     children: t.Iterable[Node], first: str, second: int, third_arg: str, **attrs: t.Any
 ) -> Template:
     # Ensure type correctness of props at runtime for testing purposes
@@ -528,7 +528,7 @@ def TemplateComponent(
 
 def test_interpolated_template_component():
     node = html(
-        t'<{TemplateComponent} first=1 second={99} third-arg="comp1" class="my-comp">Hello, Component!</{TemplateComponent}>'
+        t'<{FunctionComponent} first=1 second={99} third-arg="comp1" class="my-comp">Hello, Component!</{FunctionComponent}>'
     )
     assert node == Element(
         "div",
@@ -548,7 +548,7 @@ def test_interpolated_template_component():
 
 def test_invalid_component_invocation():
     with pytest.raises(TypeError):
-        _ = html(t"<{TemplateComponent}>Missing props</{TemplateComponent}>")  # type: ignore
+        _ = html(t"<{FunctionComponent}>Missing props</{FunctionComponent}>")  # type: ignore
 
 
 def ColumnsComponent() -> Template:
@@ -581,7 +581,7 @@ def test_component_passed_as_attr_value():
         return t"<{sub_component} {attrs}>{children}</{sub_component}>"
 
     node = html(
-        t'<{Wrapper} sub-component={TemplateComponent} class="wrapped" first=1 second={99} third-arg="comp1"><p>Inside wrapper</p></{Wrapper}>'
+        t'<{Wrapper} sub-component={FunctionComponent} class="wrapped" first=1 second={99} third-arg="comp1"><p>Inside wrapper</p></{Wrapper}>'
     )
     assert node == Element(
         "div",
@@ -644,7 +644,7 @@ def test_component_returning_explicit_fragment():
 
 
 @dataclass
-class Avatar:
+class ClassComponent:
     """Example class-based component."""
 
     user_name: str
@@ -662,8 +662,38 @@ class Avatar:
         )
 
 
-def test_class_based_component():
-    avatar = Avatar(
+def test_class_component_implicit_invocation():
+    node = html(
+        t"<{ClassComponent} user-name='Alice' image-url='https://example.com/alice.png' />"
+    )
+    assert node == Element(
+        "div",
+        attrs={"class": "avatar"},
+        children=[
+            Element(
+                "a",
+                attrs={"href": "#"},
+                children=[
+                    Element(
+                        "img",
+                        attrs={
+                            "src": "https://example.com/alice.png",
+                            "alt": "Avatar of Alice",
+                        },
+                    )
+                ],
+            ),
+            Element("span", children=[Text("Alice")]),
+        ],
+    )
+    assert (
+        str(node)
+        == '<div class="avatar"><a href="#"><img src="https://example.com/alice.png" alt="Avatar of Alice" /></a><span>Alice</span></div>'
+    )
+
+
+def test_class_component_direct_invocation():
+    avatar = ClassComponent(
         user_name="Alice",
         image_url="https://example.com/alice.png",
         homepage="https://example.com/users/alice",

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -131,6 +131,41 @@ def test_conversions():
 
 
 # --------------------------------------------------------------------------
+# Interpolated non-text content
+# --------------------------------------------------------------------------
+
+
+def test_interpolated_false_content():
+    node = html(t"<div>{False}</div>")
+    assert node == Element("div", children=[])
+    assert str(node) == "<div></div>"
+
+
+def test_interpolated_none_content():
+    node = html(t"<div>{None}</div>")
+    assert node == Element("div", children=[])
+    assert str(node) == "<div></div>"
+
+
+def test_interpolated_zero_arg_function():
+    def get_value():
+        return "dynamic"
+
+    node = html(t"<p>The value is {get_value}.</p>")
+    assert node == Element(
+        "p", children=[Text("The value is "), Text("dynamic"), Text(".")]
+    )
+
+
+def test_interpolated_multi_arg_function_fails():
+    def add(a, b):
+        return a + b
+
+    with pytest.raises(TypeError):
+        _ = html(t"<p>The sum is {add}.</p>")
+
+
+# --------------------------------------------------------------------------
 # Raw HTML injection tests
 # --------------------------------------------------------------------------
 

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -1,6 +1,6 @@
 import datetime
 import typing as t
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from string.templatelib import Template
 
 import pytest
@@ -651,6 +651,7 @@ class ClassComponent:
     user_name: str
     image_url: str
     homepage: str = "#"
+    children: t.Iterable[Node] = field(default_factory=list)
 
     def __call__(self) -> Node:
         return html(
@@ -659,13 +660,14 @@ class ClassComponent:
             t"<img src='{self.image_url}' alt='{f'Avatar of {self.user_name}'}' />"
             t"</a>"
             t"<span>{self.user_name}</span>"
-            t"</div>"
+            t"{self.children}"
+            t"</div>",
         )
 
 
 def test_class_component_implicit_invocation():
     node = html(
-        t"<{ClassComponent} user-name='Alice' image-url='https://example.com/alice.png' />"
+        t"<{ClassComponent} user-name='Alice' image-url='https://example.com/alice.png'>Fun times!</{ClassComponent}>"
     )
     assert node == Element(
         "div",
@@ -685,11 +687,12 @@ def test_class_component_implicit_invocation():
                 ],
             ),
             Element("span", children=[Text("Alice")]),
+            Text("Fun times!"),
         ],
     )
     assert (
         str(node)
-        == '<div class="avatar"><a href="#"><img src="https://example.com/alice.png" alt="Avatar of Alice" /></a><span>Alice</span></div>'
+        == '<div class="avatar"><a href="#"><img src="https://example.com/alice.png" alt="Avatar of Alice" /></a><span>Alice</span>Fun times!</div>'
     )
 
 

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -512,7 +512,7 @@ def test_interpolated_style_attribute():
 
 
 def TemplateComponent(
-    *children: Node, first: str, second: int, third_arg: str, **attrs: t.Any
+    children: t.Iterable[Node], first: str, second: int, third_arg: str, **attrs: t.Any
 ) -> Template:
     # Ensure type correctness of props at runtime for testing purposes
     assert isinstance(first, str)
@@ -575,7 +575,9 @@ def test_fragment_from_component():
 
 
 def test_component_passed_as_attr_value():
-    def Wrapper(*children: Node, sub_component: t.Callable, **attrs: t.Any) -> Template:
+    def Wrapper(
+        children: t.Iterable[Node], sub_component: t.Callable, **attrs: t.Any
+    ) -> Template:
         return t"<{sub_component} {attrs}>{children}</{sub_component}>"
 
     node = html(


### PR DESCRIPTION
This PR represents a big set of changes to support class-based components, as described in #53. When merged, this resolves #53 .

The `README.md` is updated to reflect these changes, all tests are updated, and there are very many new tests.

For a basic description of these changes from a user's perspective, see [my comments to #53 here](https://github.com/t-strings/tdom/issues/53#issuecomment-3293837917). 

There is also a new `CallableInfo` facility: a frozen dataclass that holds on to _just_ the information we need when inspecting a callable (using `inspect.signature()` now) to understand how to invoke it. We do this (rather than holding on to `inspect.Signature` instances directly) for cachability; `get_callable_info(c: Callable)` sits behind an `@lru_cache()`.