### PR TITLE
Content node not escaping

### DIFF
--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -116,7 +116,7 @@ def test_interpolated_closed_tag():
     node = html(t"<style>{theme_styles}</style>")
     print (str(node))
     assert node == Element('style', children=[Text(theme_styles)])
-    assert str(node) == f"<style>{LT}/style{GT}{LT}script{GT}myapp.openFloodGates(){LT}/script{GT}</style>"
+    assert str(node) == f"<style>{LT}/style{GT}{LT}script{GT}myapp.openFloodGates(){LT}/script{GT}{LT}style{GT}</style>"
 
 
 class Convertible:


### PR DESCRIPTION
This is a test to try to demonstrate the issue in #68 

```
========================================================================================== FAILURES ==========================================================================================
________________________________________________________________________________ test_interpolated_closed_tag ________________________________________________________________________________

    def test_interpolated_closed_tag():
        LT = '&lt;'
        GT = '&gt;'
        theme_styles = "</style><script>myapp.openFloodGates()</script><style>"
        node = html(t"<style>{theme_styles}</style>")
        print (str(node))
        assert node == Element('style', children=[Text(theme_styles)])
>       assert str(node) == f"<style>{LT}/style{GT}{LT}script{GT}myapp.openFloodGates(){LT}/script{GT}{LT}style{GT}</style>"
E       AssertionError: assert '<style></sty...tyle></style>' == '<style>&lt;/...e&gt;</style>'
E         
E         - <style>&lt;/style&gt;&lt;script&gt;myapp.openFloodGates()&lt;/script&gt;&lt;style&gt;</style>
E         ?        ^^^^      ^^^^^^^^      ^^^^                      ^^^^       ^^^^^^^^     ^^^^
E         + <style></style><script>myapp.openFloodGates()</script><style></style>
E         ?        ^      ^^      ^                      ^       ^^     ^

tdom/processor_test.py:119: AssertionError
------------------------------------------------------------------------------------ Captured stdout call ------------------------------------------------------------------------------------
<style></style><script>myapp.openFloodGates()</script><style></style>
```