### PR TITLE
Wrap up low level placeholder handling into PlaceholderConfig helper

### DIFF
--- a/tdom/placeholders_test.py
+++ b/tdom/placeholders_test.py
@@ -1,52 +1,52 @@
 import pytest
 
 from .placeholders import (
-    _PLACEHOLDER_PREFIX,
-    _PLACEHOLDER_SUFFIX,
+    make_placeholder_config,
     PlaceholderState,
-    find_placeholders,
-    make_placeholder,
-    match_placeholders,
 )
 
 
 def test_make_placeholder() -> None:
-    assert make_placeholder(0) == f"{_PLACEHOLDER_PREFIX}0{_PLACEHOLDER_SUFFIX}"
-    assert make_placeholder(42) == f"{_PLACEHOLDER_PREFIX}42{_PLACEHOLDER_SUFFIX}"
+    config = make_placeholder_config()
+    assert config.make_placeholder(0) == f"{config.prefix}0{config.suffix}"
+    assert config.make_placeholder(42) == f"{config.prefix}42{config.suffix}"
 
 
 def test_match_placeholders() -> None:
-    s = f"Start {_PLACEHOLDER_PREFIX}0{_PLACEHOLDER_SUFFIX} middle {_PLACEHOLDER_PREFIX}1{_PLACEHOLDER_SUFFIX} end"
-    matches = match_placeholders(s)
+    config = make_placeholder_config()
+    s = f"Start {config.prefix}0{config.suffix} middle {config.prefix}1{config.suffix} end"
+    matches = config.match_placeholders(s)
     assert len(matches) == 2
-    assert matches[0].group(0) == f"{_PLACEHOLDER_PREFIX}0{_PLACEHOLDER_SUFFIX}"
+    assert matches[0].group(0) == f"{config.prefix}0{config.suffix}"
     assert matches[0][1] == "0"
-    assert matches[1].group(0) == f"{_PLACEHOLDER_PREFIX}1{_PLACEHOLDER_SUFFIX}"
+    assert matches[1].group(0) == f"{config.prefix}1{config.suffix}"
     assert matches[1][1] == "1"
 
 
 def test_find_placeholders() -> None:
-    s = f"Hello {_PLACEHOLDER_PREFIX}0{_PLACEHOLDER_SUFFIX}, today is {_PLACEHOLDER_PREFIX}1{_PLACEHOLDER_SUFFIX}."
-    pt = find_placeholders(s)
+    config = make_placeholder_config()
+    s = f"Hello {config.prefix}0{config.suffix}, today is {config.prefix}1{config.suffix}."
+    pt = config.find_placeholders(s)
     assert pt.strings == ("Hello ", ", today is ", ".")
     assert pt.i_indexes == (0, 1)
 
     literal_s = "No placeholders here."
-    literal_pt = find_placeholders(literal_s)
+    literal_pt = config.find_placeholders(literal_s)
     assert literal_pt.strings == (literal_s,)
     assert literal_pt.i_indexes == ()
 
 
 def test_placeholder_state() -> None:
-    state = PlaceholderState()
+    config = make_placeholder_config()
+    state = PlaceholderState(config=config)
     assert state.is_empty
 
     p0 = state.add_placeholder(0)
-    assert p0 == make_placeholder(0)
+    assert p0 == config.make_placeholder(0)
     assert not state.is_empty
 
     p1 = state.add_placeholder(1)
-    assert p1 == make_placeholder(1)
+    assert p1 == config.make_placeholder(1)
 
     text = f"Values: {p0}, {p1}"
     pt = state.remove_placeholders(text)
@@ -55,4 +55,4 @@ def test_placeholder_state() -> None:
     assert state.is_empty
 
     with pytest.raises(ValueError):
-        state.remove_placeholders(f"Unknown placeholder: {make_placeholder(2)}")
+        state.remove_placeholders(f"Unknown placeholder: {config.make_placeholder(2)}")

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -7,7 +7,7 @@ import pytest
 from markupsafe import Markup
 
 from .nodes import Comment, DocumentType, Element, Fragment, Node, Text
-from .placeholders import _PLACEHOLDER_PREFIX, _PLACEHOLDER_SUFFIX
+from .placeholders import make_placeholder_config
 from .processor import html
 
 # --------------------------------------------------------------------------
@@ -597,25 +597,25 @@ def test_interpolated_attribute_value_tricky_multiple_placeholders():
 
 
 def test_placeholder_collision_avoidance():
+    config = make_placeholder_config()
     # This test is to ensure that our placeholder detection avoids collisions
     # even with content that might look like a placeholder.
     tricky = "123"
     template = Template(
         '<div data-tricky="',
-        _PLACEHOLDER_PREFIX,
+        config.prefix,
         Interpolation(tricky, "tricky"),
-        _PLACEHOLDER_SUFFIX,
+        config.suffix,
         '"></div>',
     )
     node = html(template)
     assert node == Element(
         "div",
-        attrs={"data-tricky": _PLACEHOLDER_PREFIX + tricky + _PLACEHOLDER_SUFFIX},
+        attrs={"data-tricky": config.prefix + tricky + config.suffix},
         children=[],
     )
     assert (
-        str(node)
-        == f'<div data-tricky="{_PLACEHOLDER_PREFIX}{tricky}{_PLACEHOLDER_SUFFIX}"></div>'
+        str(node) == f'<div data-tricky="{config.prefix}{tricky}{config.suffix}"></div>'
     )
 
 


### PR DESCRIPTION
- Move low level placeholder operations and constants into placeholder config helper class.
- This is to avoid potential free-threading issues but overall we probably shouldn't be using dynamic module level variables anyways.
- Long term we probably want to share the placeholder configuration across a "group" of parsers but I think this is ok for now.