### PR TITLE
Experiment with a more consistent (T)ParentNode only interface.

### DIFF
--- a/tdom/nodes.py
+++ b/tdom/nodes.py
@@ -141,3 +141,6 @@ class Element(Node):
             return f"<{self.tag}{attrs_str}></{self.tag}>"
         children_str = self._children_to_str()
         return f"<{self.tag}{attrs_str}>{children_str}</{self.tag}>"
+
+
+type ParentNode = Element | Fragment

--- a/tdom/parser_test.py
+++ b/tdom/parser_test.py
@@ -23,12 +23,12 @@ def test_parse_empty():
 
 def test_parse_text():
     node = TemplateParser.parse(t"Hello, world!")
-    assert node == TText.literal("Hello, world!")
+    assert node == TFragment(children=(TText.literal("Hello, world!"),))
 
 
 def test_parse_text_with_entities():
     node = TemplateParser.parse(t"Panini&apos;s")
-    assert node == TText.literal("Panini's")
+    assert node == TFragment(children=(TText.literal("Panini's"),))
 
 
 def test_parse_void_element():
@@ -88,12 +88,12 @@ def test_parse_element_attribute_order():
 
 def test_parse_comment():
     node = TemplateParser.parse(t"<!-- This is a comment -->")
-    assert node == TComment.literal(" This is a comment ")
+    assert node == TFragment(children=(TComment.literal(" This is a comment "),))
 
 
 def test_parse_doctype():
     node = TemplateParser.parse(t"<!DOCTYPE html>")
-    assert node == TDocumentType("html")
+    assert node == TFragment(children=(TDocumentType("html"),))
 
 
 def test_parse_multiple_voids():

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -23,19 +23,19 @@ def test_parse_empty():
 
 def test_parse_text():
     node = html(t"Hello, world!")
-    assert node == Text("Hello, world!")
+    assert node == Fragment(children=[Text("Hello, world!")])
     assert str(node) == "Hello, world!"
 
 
 def test_parse_comment():
     node = html(t"<!--This is a comment-->")
-    assert node == Comment("This is a comment")
+    assert node == Fragment(children=[Comment("This is a comment")])
     assert str(node) == "<!--This is a comment-->"
 
 
 def test_parse_document_type():
     node = html(t"<!doctype html>")
-    assert node == DocumentType("html")
+    assert node == Fragment(children=[DocumentType("html")])
     assert str(node) == "<!DOCTYPE html>"
 
 
@@ -1056,7 +1056,7 @@ def test_nested_component_gh23():
         return html(t"{'Hello World'}")
 
     node = html(t"<{Header} />")
-    assert node == Text("Hello World")
+    assert node == Fragment(children=[Text("Hello World")])
     assert str(node) == "Hello World"
 
 
@@ -1289,7 +1289,7 @@ def test_attribute_type_component():
         t"data-false={a_false} data-none={a_none} data-float={a_float} "
         t"data-dt={a_dt} {spread_attrs}/>"
     )
-    assert node == Text("Looks good!")
+    assert node == Fragment(children=[Text("Looks good!")])
     assert str(node) == "Looks good!"
 
 

--- a/tdom/tnodes.py
+++ b/tdom/tnodes.py
@@ -94,4 +94,4 @@ class TComponent(TNode):
     children: tuple[TNode, ...] = field(default_factory=tuple)
 
 
-type TTag = TElement | TComponent | TFragment
+type TParentNode = TElement | TComponent | TFragment


### PR DESCRIPTION
I'm not sure this is what we want yet.  I put it together for #94 but maybe other things need to line up before we're ready to act on this.  Specifically the instance check in `def html()` seems not ideal if we are calling `html()` all over the place but if we're only calling it a few times at the top-level then maybe its fine.