### PR TITLE
Prefactor some parts to reduce size of other PR

### DIFF
--- a/tdom/format.py
+++ b/tdom/format.py
@@ -29,7 +29,11 @@ def convert[T](value: T, conversion: t.Literal["a", "r", "s"] | None) -> T | str
 type FormatMatcher = t.Callable[[str], bool]
 """A predicate function that returns True if a given format specifier matches its criteria."""
 
-type CustomFormatter = t.Callable[[object, str], str]
+
+V = t.TypeVar("V", bound=object)
+
+
+type CustomFormatter[V] = t.Callable[[V, str], object]
 """A function that takes a value and a format specifier and returns a formatted string."""
 
 type MatcherAndFormatter = tuple[str | FormatMatcher, CustomFormatter]

--- a/tdom/htmlspec.py
+++ b/tdom/htmlspec.py
@@ -1,0 +1,24 @@
+# See https://developer.mozilla.org/en-US/docs/Glossary/Void_element
+VOID_ELEMENTS = frozenset(
+    [
+        "area",
+        "base",
+        "br",
+        "col",
+        "embed",
+        "hr",
+        "img",
+        "input",
+        "link",
+        "meta",
+        "param",
+        "source",
+        "track",
+        "wbr",
+    ]
+)
+
+
+CDATA_CONTENT_ELEMENTS = frozenset(["script", "style"])
+RCDATA_CONTENT_ELEMENTS = frozenset(["textarea", "title"])
+CONTENT_ELEMENTS = CDATA_CONTENT_ELEMENTS | RCDATA_CONTENT_ELEMENTS

--- a/tdom/nodes.py
+++ b/tdom/nodes.py
@@ -7,30 +7,7 @@ from .escaping import (
     escape_html_text,
 )
 
-# See https://developer.mozilla.org/en-US/docs/Glossary/Void_element
-VOID_ELEMENTS = frozenset(
-    [
-        "area",
-        "base",
-        "br",
-        "col",
-        "embed",
-        "hr",
-        "img",
-        "input",
-        "link",
-        "meta",
-        "param",
-        "source",
-        "track",
-        "wbr",
-    ]
-)
-
-
-CDATA_CONTENT_ELEMENTS = frozenset(["script", "style"])
-RCDATA_CONTENT_ELEMENTS = frozenset(["textarea", "title"])
-CONTENT_ELEMENTS = CDATA_CONTENT_ELEMENTS | RCDATA_CONTENT_ELEMENTS
+from .htmlspec import VOID_ELEMENTS, CONTENT_ELEMENTS
 
 
 # FUTURE: add a pretty-printer to nodes for debugging

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field
 from html.parser import HTMLParser
 from string.templatelib import Interpolation, Template
 
-from .nodes import VOID_ELEMENTS
+from .htmlspec import VOID_ELEMENTS
 from .placeholders import PlaceholderState
 from .tnodes import (
     TAttribute,

--- a/tdom/parser_test.py
+++ b/tdom/parser_test.py
@@ -1,7 +1,9 @@
+from string.templatelib import Template, Interpolation
+
 import pytest
 
 from .parser import TemplateParser
-from .placeholders import TemplateRef
+from .placeholders import TemplateRef, make_placeholder_config
 from .tnodes import (
     TComment,
     TComponent,
@@ -465,3 +467,20 @@ def test_adjacent_end_component_tag_error():
 
     with pytest.raises(ValueError):
         _ = TemplateParser.parse(t"<{Component}></{Component}{Component}>")
+
+
+def test_placeholder_collision_avoidance():
+    config = make_placeholder_config()
+    # This test is to ensure that our placeholder detection avoids collisions
+    # even with content that might look like a placeholder.
+    tricky = "0"
+    template = Template(
+        f'<div data-tricky="{config.prefix}',
+        Interpolation(tricky, "tricky", None, ""),
+        f'{config.suffix}"></div>',
+    )
+    tnode = TemplateParser.parse(template)
+    value_ref = TemplateRef(strings=(config.prefix, config.suffix), i_indexes=(0,))
+    assert tnode == TElement(
+        "div", attrs=(TTemplatedAttribute(name="data-tricky", value_ref=value_ref),)
+    )

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -31,11 +31,7 @@ from .parser import (
 from .placeholders import TemplateRef
 from .template_utils import template_from_parts
 from .utils import CachableTemplate, LastUpdatedOrderedDict
-
-
-@t.runtime_checkable
-class HasHTMLDunder(t.Protocol):
-    def __html__(self) -> str: ...  # pragma: no cover
+from .protocols import HasHTMLDunder
 
 
 # TODO: in Ian's original PR, this caching was tethered to the

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -1,6 +1,6 @@
 import sys
 import typing as t
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Sequence, Callable
 from functools import lru_cache
 from string.templatelib import Interpolation, Template
 from dataclasses import dataclass
@@ -65,7 +65,17 @@ def _format_unsafe(value: object, format_spec: str) -> str:
     return str(value)
 
 
-CUSTOM_FORMATTERS = (("safe", _format_safe), ("unsafe", _format_unsafe))
+def _format_callback(value: Callable[..., object], format_spec: str) -> object:
+    """Execute a callback and return the value."""
+    assert format_spec == "callback"
+    return value()
+
+
+CUSTOM_FORMATTERS = (
+    ("safe", _format_safe),
+    ("unsafe", _format_unsafe),
+    ("callback", _format_callback),
+)
 
 
 def format_interpolation(interpolation: Interpolation) -> object:

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 
 from markupsafe import Markup
 
-from .callables import get_callable_info
+from .callables import get_callable_info, CallableInfo
 from .format import format_interpolation as base_format_interpolation
 from .format import format_template
 from .nodes import Comment, DocumentType, Element, Fragment, Node, Text
@@ -433,6 +433,38 @@ def _kebab_to_snake(name: str) -> str:
     return name.replace("-", "_").lower()
 
 
+def _prep_component_kwargs(
+    callable_info: CallableInfo,
+    attrs: AttributesDict,
+    system_kwargs: dict[str, object],
+):
+    if callable_info.requires_positional:
+        raise TypeError(
+            "Component callables cannot have required positional arguments."
+        )
+
+    kwargs: AttributesDict = {}
+
+    # Add all supported attributes
+    for attr_name, attr_value in attrs.items():
+        snake_name = _kebab_to_snake(attr_name)
+        if snake_name in callable_info.named_params or callable_info.kwargs:
+            kwargs[snake_name] = attr_value
+
+    for attr_name, attr_value in system_kwargs.items():
+        if attr_name in callable_info.named_params or callable_info.kwargs:
+            kwargs[attr_name] = attr_value
+
+    # Check to make sure we've fully satisfied the callable's requirements
+    missing = callable_info.required_named_params - kwargs.keys()
+    if missing:
+        raise TypeError(
+            f"Missing required parameters for component: {', '.join(missing)}"
+        )
+
+    return kwargs
+
+
 def _invoke_component(
     attrs: AttributesDict,
     children: list[Node],  # TODO: why not TNode, though?
@@ -473,29 +505,9 @@ def _invoke_component(
         )
     callable_info = get_callable_info(value)
 
-    if callable_info.requires_positional:
-        raise TypeError(
-            "Component callables cannot have required positional arguments."
-        )
-
-    kwargs: AttributesDict = {}
-
-    # Add all supported attributes
-    for attr_name, attr_value in attrs.items():
-        snake_name = _kebab_to_snake(attr_name)
-        if snake_name in callable_info.named_params or callable_info.kwargs:
-            kwargs[snake_name] = attr_value
-
-    # Add children if appropriate
-    if "children" in callable_info.named_params or callable_info.kwargs:
-        kwargs["children"] = tuple(children)
-
-    # Check to make sure we've fully satisfied the callable's requirements
-    missing = callable_info.required_named_params - kwargs.keys()
-    if missing:
-        raise TypeError(
-            f"Missing required parameters for component: {', '.join(missing)}"
-        )
+    kwargs = _prep_component_kwargs(
+        callable_info, attrs, system_kwargs={"children": tuple(children)}
+    )
 
     result = value(**kwargs)
     return _node_from_value(result)

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -247,7 +247,7 @@ def test_interpolated_zero_arg_function():
     def get_value():
         return "dynamic"
 
-    node = html(t"<p>The value is {get_value}.</p>")
+    node = html(t"<p>The value is {get_value:callback}.</p>")
     assert node == Element(
         "p", children=[Text("The value is "), Text("dynamic"), Text(".")]
     )
@@ -258,7 +258,7 @@ def test_interpolated_multi_arg_function_fails():
         return a + b
 
     with pytest.raises(TypeError):
-        _ = html(t"<p>The sum is {add}.</p>")
+        _ = html(t"<p>The sum is {add:callback}.</p>")
 
 
 # --------------------------------------------------------------------------

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -1,14 +1,13 @@
 import datetime
 import typing as t
 from dataclasses import dataclass, field
-from string.templatelib import Interpolation, Template
+from string.templatelib import Template
 from itertools import product
 
 import pytest
 from markupsafe import Markup
 
 from .nodes import Comment, DocumentType, Element, Fragment, Node, Text
-from .placeholders import make_placeholder_config
 from .processor import html
 
 # --------------------------------------------------------------------------
@@ -656,27 +655,6 @@ def test_attr_merge_other_literal_attr_intact():
     node = html(t'<img title="default" {dict(alt="fresh")}>')
     assert node == Element("img", {"title": "default", "alt": "fresh"})
     assert str(node) == '<img title="default" alt="fresh" />'
-
-
-def test_placeholder_collision_avoidance():
-    config = make_placeholder_config()
-    # This test is to ensure that our placeholder detection avoids collisions
-    # even with content that might look like a placeholder.
-    tricky = "0"
-    template = Template(
-        f'<div data-tricky="{config.prefix}',
-        Interpolation(tricky, "tricky", None, ""),
-        f'{config.suffix}"></div>',
-    )
-    node = html(template)
-    assert node == Element(
-        "div",
-        attrs={"data-tricky": config.prefix + tricky + config.suffix},
-        children=[],
-    )
-    assert (
-        str(node) == f'<div data-tricky="{config.prefix}{tricky}{config.suffix}"></div>'
-    )
 
 
 #

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -8,7 +8,9 @@ import pytest
 from markupsafe import Markup
 
 from .nodes import Comment, DocumentType, Element, Fragment, Node, Text
-from .processor import html
+from .processor import html, _prep_component_kwargs
+from .callables import get_callable_info
+
 
 # --------------------------------------------------------------------------
 # Basic HTML parsing tests
@@ -1079,6 +1081,20 @@ def test_interpolated_template_component_no_children_provided():
 def test_invalid_component_invocation():
     with pytest.raises(TypeError):
         _ = html(t"<{FunctionComponent}>Missing props</{FunctionComponent}>")
+
+
+def test_prep_component_kwargs_named():
+    def InputElement(size=10, type="text"):
+        pass
+
+    callable_info = get_callable_info(InputElement)
+    assert _prep_component_kwargs(callable_info, {"size": 20}, system_kwargs={}) == {
+        "size": 20
+    }
+    assert _prep_component_kwargs(
+        callable_info, {"type": "email"}, system_kwargs={}
+    ) == {"type": "email"}
+    assert _prep_component_kwargs(callable_info, {}, system_kwargs={}) == {}
 
 
 def FunctionComponentNoChildren(first: str, second: int, third_arg: str) -> Template:

--- a/tdom/protocols.py
+++ b/tdom/protocols.py
@@ -1,0 +1,6 @@
+import typing as t
+
+
+@t.runtime_checkable
+class HasHTMLDunder(t.Protocol):
+    def __html__(self) -> str: ...  # pragma: no cover

--- a/tdom/protocols_test.py
+++ b/tdom/protocols_test.py
@@ -1,0 +1,24 @@
+from markupsafe import Markup, escape
+
+
+from .protocols import HasHTMLDunder
+
+
+class LTEntity:
+    def __html__(self):
+        return "&lt;"
+
+
+def test_custom_html_dunder_isinstance_has_html_dunder():
+    lt = LTEntity()
+    assert isinstance(lt, HasHTMLDunder)
+
+
+def test_markup_isinstance_has_html_dunder():
+    wrapped_html = Markup(escape("<div>"))
+    assert isinstance(wrapped_html, HasHTMLDunder)
+
+
+def test_str_not_isinstance_has_html_dunder():
+    html_str = "<div>"
+    assert not isinstance(html_str, HasHTMLDunder)

--- a/tdom/sentinel.py
+++ b/tdom/sentinel.py
@@ -1,0 +1,10 @@
+"""
+Simple sentinel, ie. NOT_SET / NOT_GIVEN for use in project.
+"""
+
+
+class NotSet:
+    pass
+
+
+NOT_SET = NotSet()

--- a/tdom/template_utils.py
+++ b/tdom/template_utils.py
@@ -74,3 +74,14 @@ class TemplateRef:
             raise ValueError(
                 "TemplateRef must have one more string than interpolation indexes."
             )
+
+    def __iter__(self):
+        index = 0
+        last_s_index = len(self.strings) - 1
+        while index <= last_s_index:
+            s = self.strings[index]
+            if s:
+                yield s
+            if index < last_s_index:
+                yield self.i_indexes[index]
+            index += 1

--- a/tdom/template_utils.py
+++ b/tdom/template_utils.py
@@ -85,3 +85,8 @@ class TemplateRef:
             if index < last_s_index:
                 yield self.i_indexes[index]
             index += 1
+
+    def resolve(self, interpolations: tuple[Interpolation, ...]) -> Template:
+        """Use the given interpolations to resolve this reference template into a Template."""
+        resolved = [interpolations[i_index] for i_index in self.i_indexes]
+        return template_from_parts(self.strings, resolved)

--- a/tdom/template_utils_test.py
+++ b/tdom/template_utils_test.py
@@ -91,3 +91,13 @@ def test_template_ref_iter_complete():
         5,
         "jkl",
     ]
+
+
+def test_template_ref_resolve():
+    src_t = t"{'a'}b{'c'}d{'e'}f"
+    src_ref = TemplateRef(
+        strings=src_t.strings, i_indexes=tuple(range(len(src_t.interpolations)))
+    )
+    resolved_t = src_ref.resolve(src_t.interpolations)
+    assert resolved_t.values == ("a", "c", "e")
+    assert resolved_t.strings == ("", "b", "d", "f")

--- a/tdom/template_utils_test.py
+++ b/tdom/template_utils_test.py
@@ -55,3 +55,39 @@ def test_combine_template_refs():
     assert combine_template_refs(*template_refs) == TemplateRef.from_naive_template(
         t"abc{0}def{1}{2}ghi"
     )
+
+
+def test_template_ref_iter_singleton():
+    assert list(TemplateRef.from_naive_template(t"{1}")) == [1]
+
+
+def test_template_ref_iter_empty():
+    assert list(TemplateRef.from_naive_template(t"")) == []
+
+
+def test_template_ref_iter_empty_prefix():
+    assert list(TemplateRef.from_naive_template(t"{1}def")) == [1, "def"]
+
+
+def test_template_ref_iter_empty_suffix():
+    assert list(TemplateRef.from_naive_template(t"abc{1}")) == ["abc", 1]
+
+
+def test_template_ref_iter_literal():
+    assert list(TemplateRef.from_naive_template(t"abc")) == ["abc"]
+
+
+def test_template_ref_iter_only_interpolations():
+    assert list(TemplateRef.from_naive_template(t"{1}{3}{5}")) == [1, 3, 5]
+
+
+def test_template_ref_iter_complete():
+    assert list(TemplateRef.from_naive_template(t"abc{1}def{3}ghi{5}jkl")) == [
+        "abc",
+        1,
+        "def",
+        3,
+        "ghi",
+        5,
+        "jkl",
+    ]


### PR DESCRIPTION
- new modules
  - start preparing for more html spec constants by creating new module: `htmlspec.py`
  - move html dunder protocol into a module so we can more easily share it: `protocols.py`
  - Add sentinel for use in the project (until Python standardizes one, in 3.15? maybe): `sentinel.py`
- `TemplateRef` additions
  - add helper method for TemplateRef that iterates parts, omitting empty strings, like `Template.__iter__` does.
  - add helper method to TemplateRef that resolves the interpolation values from a paired `Template` object in between the `TemplateRef` `strings` based on the `i_indexes`.
- new feature: `"callback"` format_spec triggers new formatter
  - Add callback formatter that executes a zero-arg callable before resolving the template values.  This would be opt-in instead of any Callable passed into the `Template` being called automatically.