### PR TITLE
Import Sequence, Iterable and Callable from collections.abc.

### DIFF
--- a/tdom/callables.py
+++ b/tdom/callables.py
@@ -1,5 +1,6 @@
 import sys
 import typing as t
+from collections.abc import Callable
 from dataclasses import dataclass
 from functools import lru_cache
 
@@ -24,7 +25,7 @@ class CallableInfo:
     """Whether the callable accepts **kwargs."""
 
     @classmethod
-    def from_callable(cls, c: t.Callable) -> t.Self:
+    def from_callable(cls, c: Callable) -> t.Self:
         """Create a CallableInfo from a callable."""
         import inspect
 
@@ -71,6 +72,6 @@ class CallableInfo:
 
 
 @lru_cache(maxsize=0 if "pytest" in sys.modules else 512)
-def get_callable_info(c: t.Callable) -> CallableInfo:
+def get_callable_info(c: Callable) -> CallableInfo:
     """Get the CallableInfo for a callable, caching the result."""
     return CallableInfo.from_callable(c)

--- a/tdom/format.py
+++ b/tdom/format.py
@@ -1,4 +1,5 @@
 import typing as t
+from collections.abc import Callable, Sequence
 from string.templatelib import Interpolation, Template
 
 
@@ -26,14 +27,14 @@ def convert[T](value: T, conversion: t.Literal["a", "r", "s"] | None) -> T | str
         return value
 
 
-type FormatMatcher = t.Callable[[str], bool]
+type FormatMatcher = Callable[[str], bool]
 """A predicate function that returns True if a given format specifier matches its criteria."""
 
 
 V = t.TypeVar("V", bound=object)
 
 
-type CustomFormatter[V] = t.Callable[[V, str], object]
+type CustomFormatter[V] = Callable[[V, str], object]
 """A function that takes a value and a format specifier and returns a formatted string."""
 
 type MatcherAndFormatter = tuple[str | FormatMatcher, CustomFormatter]
@@ -57,7 +58,7 @@ def _format_interpolation(
     format_spec: str,
     conversion: t.Literal["a", "r", "s"] | None,
     *,
-    formatters: t.Sequence[MatcherAndFormatter],
+    formatters: Sequence[MatcherAndFormatter],
 ) -> object:
     converted = convert(value, conversion)
     if format_spec:
@@ -71,7 +72,7 @@ def _format_interpolation(
 def format_interpolation(
     interpolation: Interpolation,
     *,
-    formatters: t.Sequence[MatcherAndFormatter] = (),
+    formatters: Sequence[MatcherAndFormatter] = (),
 ) -> object:
     """
     Format an Interpolation's value according to its format spec and conversion.

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -1,4 +1,4 @@
-import typing as t
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from html.parser import HTMLParser
 from string.templatelib import Interpolation, Template
@@ -242,7 +242,7 @@ class TemplateParser(HTMLParser):
         return TSpreadAttribute(i_index=name_ref.i_indexes[0])
 
     def make_tattrs(
-        self, attrs: t.Sequence[HTMLAttribute], svg_context: bool = False
+        self, attrs: Sequence[HTMLAttribute], svg_context: bool = False
     ) -> tuple[TAttribute, ...]:
         """Build TAttributes from raw attribute tuples."""
         return tuple(self.make_tattr(attr, svg_context) for attr in attrs)
@@ -252,7 +252,7 @@ class TemplateParser(HTMLParser):
     # ------------------------------------------
 
     def make_open_tag(
-        self, tag: str, attrs: t.Sequence[HTMLAttribute], svg_context: bool = False
+        self, tag: str, attrs: Sequence[HTMLAttribute], svg_context: bool = False
     ) -> OpenTag:
         """Build an OpenTag from a raw tag and attribute tuples."""
         tag_ref = self.placeholders.remove_placeholders(tag)
@@ -333,7 +333,7 @@ class TemplateParser(HTMLParser):
     # HTMLParser tag callbacks
     # ------------------------------------------
 
-    def handle_starttag(self, tag: str, attrs: t.Sequence[HTMLAttribute]) -> None:
+    def handle_starttag(self, tag: str, attrs: Sequence[HTMLAttribute]) -> None:
         if tag == "svg":
             self._svg_depth += 1
 
@@ -347,7 +347,7 @@ class TemplateParser(HTMLParser):
         else:
             self.stack.append(open_tag)
 
-    def handle_startendtag(self, tag: str, attrs: t.Sequence[HTMLAttribute]) -> None:
+    def handle_startendtag(self, tag: str, attrs: Sequence[HTMLAttribute]) -> None:
         """Dispatch a self-closing tag, `<tag />` to specialized handlers."""
         is_svg_tag = tag == "svg"
         effective_svg_context = (self._svg_depth > 0) or is_svg_tag

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -89,7 +89,7 @@ def format_interpolation(interpolation: Interpolation) -> object:
 # --------------------------------------------------------------------------
 
 
-def _expand_aria_attr(value: object) -> t.Iterable[HTMLAttribute]:
+def _expand_aria_attr(value: object) -> Iterable[HTMLAttribute]:
     """Produce aria-* attributes based on the interpolated value for "aria"."""
     if value is None:
         return
@@ -109,7 +109,7 @@ def _expand_aria_attr(value: object) -> t.Iterable[HTMLAttribute]:
         )
 
 
-def _expand_data_attr(value: object) -> t.Iterable[Attribute]:
+def _expand_data_attr(value: object) -> Iterable[Attribute]:
     """Produce data-* attributes based on the interpolated value for "data"."""
     if value is None:
         return
@@ -125,7 +125,7 @@ def _expand_data_attr(value: object) -> t.Iterable[Attribute]:
         )
 
 
-def _substitute_spread_attrs(value: object) -> t.Iterable[Attribute]:
+def _substitute_spread_attrs(value: object) -> Iterable[Attribute]:
     """
     Substitute a spread attribute based on the interpolated value.
 
@@ -290,7 +290,7 @@ type AttributeValueAccumulator = StyleAccumulator | ClassAccumulator
 
 
 def _resolve_t_attrs(
-    attrs: t.Sequence[TAttribute], interpolations: tuple[Interpolation, ...]
+    attrs: Sequence[TAttribute], interpolations: tuple[Interpolation, ...]
 ) -> AttributesDict:
     """
     Replace placeholder values in attributes with their interpolated values.
@@ -374,7 +374,7 @@ def _resolve_html_attrs(attrs: AttributesDict) -> HTMLAttributesDict:
 
 
 def _resolve_attrs(
-    attrs: t.Sequence[TAttribute], interpolations: tuple[Interpolation, ...]
+    attrs: Sequence[TAttribute], interpolations: tuple[Interpolation, ...]
 ) -> HTMLAttributesDict:
     """
     Substitute placeholders in attributes for HTML elements.
@@ -385,7 +385,7 @@ def _resolve_attrs(
     return _resolve_html_attrs(interpolated_attrs)
 
 
-def _flatten_nodes(nodes: t.Iterable[Node]) -> list[Node]:
+def _flatten_nodes(nodes: Iterable[Node]) -> list[Node]:
     """Flatten a list of Nodes, expanding any Fragments."""
     flat: list[Node] = []
     for node in nodes:
@@ -397,7 +397,7 @@ def _flatten_nodes(nodes: t.Iterable[Node]) -> list[Node]:
 
 
 def _substitute_and_flatten_children(
-    children: t.Iterable[TNode], interpolations: tuple[Interpolation, ...]
+    children: Iterable[TNode], interpolations: tuple[Interpolation, ...]
 ) -> list[Node]:
     """Substitute placeholders in a list of children and flatten any fragments."""
     resolved = [_resolve_t_node(child, interpolations) for child in children]

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -1,5 +1,6 @@
 import datetime
 import typing as t
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from itertools import product
 from string.templatelib import Template
@@ -1029,7 +1030,7 @@ def test_style_none():
 
 
 def FunctionComponent(
-    children: t.Iterable[Node], first: str, second: int, third_arg: str, **attrs: t.Any
+    children: Iterable[Node], first: str, second: int, third_arg: str, **attrs: t.Any
 ) -> Template:
     # Ensure type correctness of props at runtime for testing purposes
     assert isinstance(first, str)
@@ -1202,7 +1203,7 @@ def test_fragment_from_component():
 
 def test_component_passed_as_attr_value():
     def Wrapper(
-        children: t.Iterable[Node], sub_component: t.Callable, **attrs: t.Any
+        children: Iterable[Node], sub_component: Callable, **attrs: t.Any
     ) -> Template:
         return t"<{sub_component} {attrs}>{children}</{sub_component}>"
 
@@ -1236,7 +1237,7 @@ def test_nested_component_gh23():
 
 
 def test_component_returning_iterable():
-    def Items() -> t.Iterable:
+    def Items() -> Iterable:
         for i in range(2):
             yield t"<li>Item {i + 1}</li>"
         yield html(t"<li>Item {3}</li>")
@@ -1276,7 +1277,7 @@ class ClassComponent:
     user_name: str
     image_url: str
     homepage: str = "#"
-    children: t.Iterable[Node] = field(default_factory=list)
+    children: Iterable[Node] = field(default_factory=list)
 
     def __call__(self) -> Node:
         return html(

--- a/tdom/template_utils.py
+++ b/tdom/template_utils.py
@@ -1,10 +1,11 @@
 import typing as t
+from collections.abc import Sequence
 from dataclasses import dataclass
 from string.templatelib import Interpolation, Template
 
 
 def template_from_parts(
-    strings: t.Sequence[str], interpolations: t.Sequence[Interpolation]
+    strings: Sequence[str], interpolations: Sequence[Interpolation]
 ) -> Template:
     """Construct a template string from the given strings and parts."""
     assert len(strings) == len(interpolations) + 1, (


### PR DESCRIPTION
Deprecated aliases in typing since ~3.9.