### PR TITLE
Pluggable Component Processor

### DIFF
--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -528,14 +528,13 @@ class IComponentProcessor(t.Protocol):
 
     def process(
         self,
-        # TODO: ? processor_api: IProcessor,
         template: Template,
         last_ctx: ProcessContext,
-        component_callable: ComponentCallable,
+        component_callable: t.Annotated[object, ComponentCallable],
         attrs: tuple[TAttribute, ...],
         component_template: Template,
         provided_attrs: tuple[Attribute, ...] = (),
-    ) -> ComponentObject | Template:
+    ) -> tuple[Template, ComponentObject | None]:
         """
         Process available component details into a queryable object or template.
         """
@@ -549,14 +548,13 @@ class ComponentProcessor(IComponentProcessor):
 
     def process(
         self,
-        # @TODO: ? processor_api: IProcessor,
         template: Template,
         last_ctx: ProcessContext,
-        component_callable: ComponentCallable,
+        component_callable: t.Annotated[object, ComponentCallable],
         attrs: tuple[TAttribute, ...],
         component_template: Template,
         provided_attrs: tuple[Attribute, ...] = (),
-    ) -> ComponentObject | Template:
+    ) -> tuple[Template, ComponentObject | None]:
         """
         Process available component details into a queryable object or template.
 
@@ -573,7 +571,28 @@ class ComponentProcessor(IComponentProcessor):
             children=component_template,
             provided_attrs=provided_attrs,
         )
-        return component_callable(**kwargs)
+        res1 = component_callable(**kwargs)  # ty: ignore[call-top-callable]
+        # This integration API seems a lot cleaner but we lose the ability for
+        # component_object.__call__ to be wrapped in any sort of context setting
+        # mechanism provided by the class, but maybe that's ok?  It could be
+        # cached on the instance although that is kind of gross.
+        if isinstance(res1, Template):
+            return res1, None
+        elif callable(res1):
+            res2 = res1() # ty: ignore[call-top-callable]
+            if isinstance(res2, Template):
+                # @TODO: It seems like we should not need this.
+                # Although our check against res2 doesn't seem to affect the
+                # return value of res1.
+                return res2, t.cast(ComponentObject, res1)
+            else:
+                raise TypeError(
+                    f"Component object must return Template when called: {type(res2)}"
+                )
+        else:
+            raise TypeError(
+                f"Component callable must return Template or Callable: {type(res1)}"
+            )
 
 
 class ITemplateProcessor(t.Protocol):
@@ -759,6 +778,33 @@ class TemplateProcessor(ITemplateProcessor):
             return attrs_str
         return ""
 
+    def _extract_component_template(
+        self,
+        template: Template,
+        attrs: tuple[TAttribute, ...],
+        start_i_index: int,
+        end_i_index: int | None,
+        check_callables: bool = True,
+    ) -> Template:
+        body_start_s_index = (
+            start_i_index
+            + 1
+            + len([1 for attr in attrs if not isinstance(attr, TLiteralAttribute)])
+        )
+        if start_i_index != end_i_index and end_i_index is not None:
+            # @TODO: We should do this during parsing.
+            if (
+                check_callables
+                and template.interpolations[start_i_index].value
+                != template.interpolations[end_i_index].value
+            ):
+                raise TypeError(
+                    "Component callable in start tag must match component callable in end tag."
+                )
+            return extract_embedded_template(template, body_start_s_index, end_i_index)
+        else:
+            return t""
+
     def _process_component(
         self,
         template: Template,
@@ -770,43 +816,15 @@ class TemplateProcessor(ITemplateProcessor):
         """
         Invoke a component and process the result into a string.
         """
-        body_start_s_index = (
-            start_i_index
-            + 1
-            + len([1 for attr in attrs if not isinstance(attr, TLiteralAttribute)])
+        children_template = self._extract_component_template(
+            template, attrs, start_i_index, end_i_index, check_callables=True
         )
-        start_i = template.interpolations[start_i_index]
-        component_callable = t.cast(ComponentCallable, start_i.value)
-        if start_i_index != end_i_index and end_i_index is not None:
-            # @TODO: We should do this during parsing.
-            children_template = extract_embedded_template(
-                template, body_start_s_index, end_i_index
-            )
-            if component_callable != template.interpolations[end_i_index].value:
-                raise TypeError(
-                    "Component callable in start tag must match component callable in end tag."
-                )
-        else:
-            children_template = t""
-
-        result_t = self.component_processor_api.process(
+        component_callable = template.interpolations[start_i_index].value
+        result_t, component_object = self.component_processor_api.process(
             template, last_ctx, component_callable, attrs, children_template
         )
-
-        if (
-            result_t is not None
-            and not isinstance(result_t, Template)
-            and callable(result_t)
-        ):
-            component_obj = t.cast(ComponentObject, result_t)  # ty: ignore[redundant-cast]
-            result_t = component_obj()
-        else:
-            component_obj = None
-
-        if isinstance(result_t, Template):
-            return self._process_template(result_t, last_ctx)
-        else:
-            raise TypeError(f"Unknown component return value: {type(result_t)}")
+        assert isinstance(component_object, object)
+        return self._process_template(result_t, last_ctx)
 
     def _process_raw_texts(
         self,

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -387,13 +387,24 @@ def _prep_component_kwargs(
     callable_info: CallableInfo,
     attrs: AttributesDict,
     children: Template,
+    provided_attrs: tuple[Attribute, ...] = (),
 ) -> AttributesDict:
+    """
+    Matchup kwargs from multiple sources to target the given callable.
+
+    The `provided_attrs` can be used by extensions that want to provide
+    kwargs even if they are not specified in a template.
+    """
     if callable_info.requires_positional:
         raise TypeError(
             "Component callables cannot have required positional arguments."
         )
 
     kwargs: AttributesDict = {}
+
+    for pattr_name, pattr_value in provided_attrs:
+        if pattr_name in callable_info.named_params or callable_info.kwargs:
+            kwargs[pattr_name] = pattr_value
 
     # Add all supported attributes
     for attr_name, attr_value in attrs.items():

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -561,6 +561,10 @@ class ComponentProcessor(IComponentProcessor):
         Default strategy just uses `_prep_component_kwargs` for `kwargs`
         injecting `children` if asked.
         """
+        if not callable(component_callable):
+            raise TypeError(
+                f"Component callable must be callable: {type(component_callable)}"
+            )
         kwargs = _prep_component_kwargs(
             get_callable_info(component_callable),
             _resolve_t_attrs(attrs, template.interpolations),

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -534,6 +534,7 @@ class IComponentProcessor(t.Protocol):
         component_callable: ComponentCallable,
         attrs: tuple[TAttribute, ...],
         component_template: Template,
+        provided_attrs: tuple[Attribute, ...] = (),
     ) -> ComponentObject | Template:
         """
         Process available component details into a queryable object or template.
@@ -554,6 +555,7 @@ class ComponentProcessor(IComponentProcessor):
         component_callable: ComponentCallable,
         attrs: tuple[TAttribute, ...],
         component_template: Template,
+        provided_attrs: tuple[Attribute, ...] = (),
     ) -> ComponentObject | Template:
         """
         Process available component details into a queryable object or template.
@@ -569,6 +571,7 @@ class ComponentProcessor(IComponentProcessor):
             get_callable_info(component_callable),
             _resolve_t_attrs(attrs, template.interpolations),
             children=component_template,
+            provided_attrs=provided_attrs,
         )
         return component_callable(**kwargs)
 

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -512,6 +512,52 @@ class CachedTemplateParserProxy(TemplateParserProxy):
         return self._to_tnode(CachableTemplate(template))
 
 
+class IComponentProcessor(t.Protocol):
+    """Isolate component processing to allow for replacement."""
+
+    def process(
+        self,
+        # TODO: ? processor_api: IProcessor,
+        template: Template,
+        last_ctx: ProcessContext,
+        component_callable: ComponentCallable,
+        attrs: tuple[TAttribute, ...],
+        component_template: Template,
+    ) -> ComponentObject | Template:
+        """
+        Process available component details into a queryable object or template.
+        """
+        ...
+
+
+class ComponentProcessor(IComponentProcessor):
+    """
+    Default component processor.
+    """
+
+    def process(
+        self,
+        # @TODO: ? processor_api: IProcessor,
+        template: Template,
+        last_ctx: ProcessContext,
+        component_callable: ComponentCallable,
+        attrs: tuple[TAttribute, ...],
+        component_template: Template,
+    ) -> ComponentObject | Template:
+        """
+        Process available component details into a queryable object or template.
+
+        Default strategy just uses `_prep_component_kwargs` for `kwargs`
+        injecting `children` if asked.
+        """
+        kwargs = _prep_component_kwargs(
+            get_callable_info(component_callable),
+            _resolve_t_attrs(attrs, template.interpolations),
+            children=component_template,
+        )
+        return component_callable(**kwargs)
+
+
 class ITemplateProcessor(t.Protocol):
     def process(
         self, root_template: Template, assume_ctx: ProcessContext | None = None
@@ -521,6 +567,10 @@ class ITemplateProcessor(t.Protocol):
 @dataclass(frozen=True)
 class TemplateProcessor(ITemplateProcessor):
     parser_api: ITemplateParserProxy = field(default_factory=CachedTemplateParserProxy)
+
+    component_processor_api: IComponentProcessor = field(
+        default_factory=ComponentProcessor
+    )
 
     escape_html_text: Callable = default_escape_html_text
 
@@ -721,16 +771,10 @@ class TemplateProcessor(ITemplateProcessor):
         else:
             children_template = t""
 
-        if not callable(component_callable):
-            raise TypeError("Component callable must be callable.")
-
-        kwargs = _prep_component_kwargs(
-            get_callable_info(component_callable),
-            _resolve_t_attrs(attrs, template.interpolations),
-            children=children_template,
+        result_t = self.component_processor_api.process(
+            template, last_ctx, component_callable, attrs, children_template
         )
 
-        result_t = component_callable(**kwargs)
         if (
             result_t is not None
             and not isinstance(result_t, Template)

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -1808,7 +1808,9 @@ class TestComponentErrors:
         def BadFunctionComp(children: Template):
             return bad_value
 
-        with pytest.raises(TypeError, match="Unknown component return value:"):
+        with pytest.raises(
+            TypeError, match="Component callable must return Template or Callable:"
+        ):
             _ = html(t"<{BadFunctionComp}>Hello</{BadFunctionComp}>")
 
     @pytest.mark.parametrize(
@@ -1821,7 +1823,9 @@ class TestComponentErrors:
 
             return component_object
 
-        with pytest.raises(TypeError, match="Unknown component return value:"):
+        with pytest.raises(
+            TypeError, match="Component object must return Template when called:"
+        ):
             _ = html(t"<{BadFactoryComp}>Hello</{BadFactoryComp}>")
 
 
@@ -1908,11 +1912,11 @@ class TestComponentProcessor:
             self,
             template: Template,
             last_ctx: ProcessContext,
-            component_callable: ComponentCallable,  # @NOTE: What should this be?
+            component_callable: object,
             attrs: tuple[TAttribute, ...],
             component_template: Template,
             provided_attrs: tuple[Attribute, ...] = (),
-        ) -> ComponentObject | Template:
+        ) -> tuple[Template, ComponentObject | None]:
             from inspect import isclass
 
             system_ctx = SystemCtx.get()

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -1827,6 +1827,7 @@ class TestComponentErrors:
 
 @dataclass()
 class SystemState:
+    request: ISimpleRequest
     components: dict[object, ComponentCallable] = field(
         default_factory=dict
     )  # t.Type[t.Protocol]
@@ -1835,7 +1836,20 @@ class SystemState:
 SystemCtx: ContextVar[SystemState | None] = ContextVar("SystemCtx", default=None)
 
 
+class ISimpleRequest(t.Protocol):
+    def make_url(self, path: str) -> str: ...
+
+
 class TestComponentProcessor:
+    @dataclass
+    class SimpleRequest(ISimpleRequest):
+        scheme: str
+        host: str
+
+        def make_url(self, path: str) -> str:
+            # @NOTE: Don't actually make URLs this way, this is just an example.
+            return f"{self.scheme}://{self.host}/{path.lstrip('/')}"
+
     class IHeader(t.Protocol):
         children: Template
         hdr_class: str
@@ -1852,18 +1866,25 @@ class TestComponentProcessor:
             return t"<div class={self.hdr_class}>{self.children}</div>"
 
     class INav(t.Protocol):
+        request: ISimpleRequest
+
         links: tuple[tuple[str, str], ...]
 
         def __call__(self) -> Template: ...
 
     @dataclass
     class Nav(INav):
+        request: ISimpleRequest
+
         links: tuple[tuple[str, str], ...] = ()
 
         nav_class: str = "nav"
 
         def _make_nav_links(self) -> list[Template]:
-            return [t"<a href={href}>{label}</a>" for label, href in self.links]
+            return [
+                t"<a href={self.request.make_url(href)}>{label}</a>"
+                for label, href in self.links
+            ]
 
         def __call__(self) -> Template:
             return t"<div class={self.nav_class}>{self._make_nav_links()}</div>"
@@ -1901,7 +1922,28 @@ class TestComponentProcessor:
                 and t.is_protocol(component_callable)
                 and component_callable in system_ctx.components
             ):
+                # Use the protocol to get the concrete component factory.
+                # @NOTE: This is using the contextvars.ContextVar to
+                # get this information but maybe in the future we'd have
+                # a way to get ctx directly from a parameter.
                 component_callable = system_ctx.components[component_callable]
+
+            # Also pass in system provided attributes to EVERY
+            # component (but it will only be used during the call if it needed.
+            # @NOTE: This is using the contextvars.ContextVar to
+            # get this information but maybe in the future we'd have
+            # a way to get ctx directly from a parameter.
+            if system_ctx is not None:
+                system_attrs = (("request", system_ctx.request),)
+                provided_attrs = provided_attrs + system_attrs
+
+            # @NOTE: We mostly just put the correct values in the right places
+            # to perform the default component processing.
+            # - `component_callable` is now the actual concrete implementation
+            # - `provided_attrs` now has attrs that might not be in the template
+            # So we can just wrap the default processor and let it do all the
+            # work. BUT... if we wanted to just replace the invocation we could
+            # do that and just return the correct thing ourselves.
             return self.default_component_processor_api.process(
                 template=template,
                 last_ctx=last_ctx,
@@ -1921,11 +1963,18 @@ class TestComponentProcessor:
             self.IHeader: self.Header,
             self.INav: self.Nav,
         }
-        with SystemCtx.set(SystemState(components=components)):
+        current_request = self.SimpleRequest(scheme="https", host="www.example.com")
+        with SystemCtx.set(SystemState(components=components, request=current_request)):
             links = [("Home", "/"), ("About", "/about")]
             header_t = t"<{self.IHeader}><{self.Logo} /><{self.INav} links={links} /></{self.IHeader}>"
             assert tp.process(header_t) == (
-                '<div class="hdr"><span class="logo">LOGO</span><div class="nav"><a href="/">Home</a><a href="/about">About</a></div></div>'
+                '<div class="hdr">'
+                '<span class="logo">LOGO</span>'
+                '<div class="nav">'
+                '<a href="https://www.example.com/">Home</a>'
+                '<a href="https://www.example.com/about">About</a>'
+                "</div>"
+                "</div>"
             )
 
 

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -1,6 +1,7 @@
 import datetime
 import typing as t
 from collections.abc import Callable
+from contextvars import ContextVar
 from dataclasses import dataclass
 from itertools import chain, product
 from string.templatelib import Template
@@ -13,15 +14,21 @@ from .callables import get_callable_info
 from .escaping import escape_html_text
 from .processor import (
     CachedTemplateParserProxy,
+    ComponentCallable,
+    ComponentObject,
+    IComponentProcessor,
+    ProcessContext,
     TemplateParserProxy,
     TemplateProcessor,
     _make_default_template_processor,
+    _resolve_t_attrs,
     make_ctx,
 )
 from .processor import (
     _prep_component_kwargs as prep_component_kwargs,
 )
 from .protocols import HasHTMLDunder
+from .tnodes import TAttribute
 
 processor_api = _make_default_template_processor(
     parser_api=TemplateParserProxy(),  # do not use cache
@@ -1815,6 +1822,62 @@ class TestComponentErrors:
 
         with pytest.raises(TypeError, match="Unknown component return value:"):
             _ = html(t"<{BadFactoryComp}>Hello</{BadFactoryComp}>")
+
+
+@dataclass()
+class SystemState:
+    path_prefix: str
+
+
+SystemCtx: ContextVar[SystemState | None] = ContextVar("SystemCtx", default=None)
+
+
+class TestComponentProcessor:
+    class SystemComponentProcessor(IComponentProcessor):
+        def process(
+            self,
+            template: Template,
+            last_ctx: ProcessContext,
+            component_callable: ComponentCallable,
+            attrs: tuple[TAttribute, ...],
+            component_template: Template,
+        ) -> ComponentObject | Template:
+
+            system_ctx = SystemCtx.get()
+            if system_ctx is not None:
+                provided_attrs = (("system_path_prefix", system_ctx.path_prefix),)
+            else:
+                provided_attrs = ()
+            kwargs = prep_component_kwargs(
+                get_callable_info(component_callable),
+                _resolve_t_attrs(attrs, template.interpolations),
+                children=component_template,
+                provided_attrs=provided_attrs,
+            )
+            return component_callable(**kwargs)
+
+    def test_replacement(self):
+        def Header(children: Template) -> Template:
+            return t"<div class=hdr>{children}</div>"
+
+        def Nav(system_path_prefix: str = "") -> Template:
+            about_url = f"{system_path_prefix.rstrip('/')}/about"
+            return t"<div class=nav><a href={about_url}>About</a></div>"
+
+        sys_comp_processor = self.SystemComponentProcessor()
+
+        tp = TemplateProcessor(component_processor_api=sys_comp_processor)
+
+        assert tp.process(t"<{Header}><{Nav} /></{Header}>") == (
+            '<div class="hdr"><div class="nav"><a href="/about">About</a></div></div>'
+        )
+        with SystemCtx.set(SystemState(path_prefix="https://example.com/")):
+            assert tp.process(t"<{Header}><{Nav} /></{Header}>") == (
+                '<div class="hdr"><div class="nav"><a href="https://example.com/about">About</a></div></div>'
+            )
+            assert tp.process(t"<{Header}><{Nav} /></{Header}>") != (
+                '<div class="hdr"><div class="nav"><a href="/about">About</a></div></div>'
+            )
 
 
 def test_integration_basic():

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -2,7 +2,7 @@ import datetime
 import typing as t
 from collections.abc import Callable
 from contextvars import ContextVar
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from itertools import chain, product
 from string.templatelib import Template
 
@@ -13,15 +13,16 @@ from markupsafe import escape as markupsafe_escape
 from .callables import get_callable_info
 from .escaping import escape_html_text
 from .processor import (
+    Attribute,
     CachedTemplateParserProxy,
     ComponentCallable,
     ComponentObject,
+    ComponentProcessor,
     IComponentProcessor,
     ProcessContext,
     TemplateParserProxy,
     TemplateProcessor,
     _make_default_template_processor,
-    _resolve_t_attrs,
     make_ctx,
 )
 from .processor import (
@@ -1826,57 +1827,105 @@ class TestComponentErrors:
 
 @dataclass()
 class SystemState:
-    path_prefix: str
+    components: dict[object, ComponentCallable] = field(
+        default_factory=dict
+    )  # t.Type[t.Protocol]
 
 
 SystemCtx: ContextVar[SystemState | None] = ContextVar("SystemCtx", default=None)
 
 
 class TestComponentProcessor:
+    class IHeader(t.Protocol):
+        children: Template
+        hdr_class: str
+
+        def __call__(self) -> Template: ...
+
+    @dataclass
+    class Header(IHeader):
+        children: Template
+
+        hdr_class: str = "hdr"
+
+        def __call__(self) -> Template:
+            return t"<div class={self.hdr_class}>{self.children}</div>"
+
+    class INav(t.Protocol):
+        links: tuple[tuple[str, str], ...]
+
+        def __call__(self) -> Template: ...
+
+    @dataclass
+    class Nav(INav):
+        links: tuple[tuple[str, str], ...] = ()
+
+        nav_class: str = "nav"
+
+        def _make_nav_links(self) -> list[Template]:
+            return [t"<a href={href}>{label}</a>" for label, href in self.links]
+
+        def __call__(self) -> Template:
+            return t"<div class={self.nav_class}>{self._make_nav_links()}</div>"
+
+    @dataclass
+    class Logo:  # NO DI / NO Protocol
+        logo_fallback: str = "LOGO"
+
+        logo_class: str = "logo"
+
+        def __call__(self) -> Template:
+            return t"<span class={self.logo_class}>{self.logo_fallback}</span>"
+
+    @dataclass
     class SystemComponentProcessor(IComponentProcessor):
+        default_component_processor_api: IComponentProcessor = field(
+            default_factory=ComponentProcessor
+        )
+
         def process(
             self,
             template: Template,
             last_ctx: ProcessContext,
-            component_callable: ComponentCallable,
+            component_callable: ComponentCallable,  # @NOTE: What should this be?
             attrs: tuple[TAttribute, ...],
             component_template: Template,
+            provided_attrs: tuple[Attribute, ...] = (),
         ) -> ComponentObject | Template:
+            from inspect import isclass
 
             system_ctx = SystemCtx.get()
-            if system_ctx is not None:
-                provided_attrs = (("system_path_prefix", system_ctx.path_prefix),)
-            else:
-                provided_attrs = ()
-            kwargs = prep_component_kwargs(
-                get_callable_info(component_callable),
-                _resolve_t_attrs(attrs, template.interpolations),
-                children=component_template,
+            if (
+                system_ctx is not None
+                and isclass(component_callable)
+                and t.is_protocol(component_callable)
+                and component_callable in system_ctx.components
+            ):
+                component_callable = system_ctx.components[component_callable]
+            return self.default_component_processor_api.process(
+                template=template,
+                last_ctx=last_ctx,
+                component_callable=component_callable,
+                attrs=attrs,
+                component_template=component_template,
                 provided_attrs=provided_attrs,
             )
-            return component_callable(**kwargs)
 
     def test_replacement(self):
-        def Header(children: Template) -> Template:
-            return t"<div class=hdr>{children}</div>"
-
-        def Nav(system_path_prefix: str = "") -> Template:
-            about_url = f"{system_path_prefix.rstrip('/')}/about"
-            return t"<div class=nav><a href={about_url}>About</a></div>"
-
         sys_comp_processor = self.SystemComponentProcessor()
 
         tp = TemplateProcessor(component_processor_api=sys_comp_processor)
 
-        assert tp.process(t"<{Header}><{Nav} /></{Header}>") == (
-            '<div class="hdr"><div class="nav"><a href="/about">About</a></div></div>'
-        )
-        with SystemCtx.set(SystemState(path_prefix="https://example.com/")):
-            assert tp.process(t"<{Header}><{Nav} /></{Header}>") == (
-                '<div class="hdr"><div class="nav"><a href="https://example.com/about">About</a></div></div>'
-            )
-            assert tp.process(t"<{Header}><{Nav} /></{Header}>") != (
-                '<div class="hdr"><div class="nav"><a href="/about">About</a></div></div>'
+        # Mapping established beforehand.
+        components: dict[object, ComponentCallable] = {  # t.Type[t.Protocol]
+            self.IHeader: self.Header,
+            self.INav: self.Nav,
+        }
+        with SystemCtx.set(SystemState(components=components)):
+            links = [("Home", "/"), ("About", "/about")]
+            header_t = t"<{self.IHeader}><{self.Logo} /><{self.INav} links={links} /></{self.IHeader}>"
+            assert tp.process(header_t) == (
+                '<div class="hdr"><span class="logo">LOGO</span><div class="nav"><a href="/">Home</a><a href="/about">About</a></div></div>'
             )
 
 


### PR DESCRIPTION
Draft of a pluggable component processor

- factor the "core" invocation of a component out into its own callable object that can be replaced
    - define protocol
    - provide default implementation
- basic test of replacing the default and using a `ContextVar` to provide a global value
