### PR TITLE
Interpolation type map for tooling

### DIFF
--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -48,6 +48,13 @@ from .parser import (
 from .protocols import HasHTMLDunder
 from .sentinel import NOT_SET, NotSet
 from .template_utils import TemplateRef
+from .types import (
+    ComponentInterpolationValue,
+    ComponentObject,
+    NormalTextInterpolationValue,
+    RawTextExactInterpolationValue,
+    RawTextInexactInterpolationValue,
+)
 from .utils import CachableTemplate, LastUpdatedOrderedDict
 
 type Attribute = tuple[str, object]
@@ -460,38 +467,6 @@ class ProcessContext:
         )
 
 
-type FunctionComponent = Callable[..., Template]
-type FactoryComponent = Callable[..., ComponentObject]
-type ComponentCallable = FunctionComponent | FactoryComponent
-type ComponentObject = Callable[[], Template]
-
-
-type NormalTextInterpolationValue = (
-    None
-    | bool  # to support `showValue and value` idiom
-    | str
-    | HasHTMLDunder
-    | Template
-    | Iterable[NormalTextInterpolationValue]
-    | object
-)
-# Applies to both escapable raw text and raw text.
-type RawTextExactInterpolationValue = (
-    None
-    | bool  # to support `showValue and value` idiom
-    | str
-    | HasHTMLDunder
-    | object
-)
-# Applies to both escapable raw text and raw text.
-type RawTextInexactInterpolationValue = (
-    None
-    | bool  # to support `showValue and value` idiom
-    | str
-    | object
-)
-
-
 class ITemplateParserProxy(t.Protocol):
     def to_tnode(self, template: Template) -> TNode: ...
 
@@ -708,7 +683,7 @@ class TemplateProcessor(ITemplateProcessor):
             + len([1 for attr in attrs if not isinstance(attr, TLiteralAttribute)])
         )
         start_i = template.interpolations[start_i_index]
-        component_callable = t.cast(ComponentCallable, start_i.value)
+        component_callable = t.cast(ComponentInterpolationValue, start_i.value)
         if start_i_index != end_i_index and end_i_index is not None:
             # @TODO: We should do this during parsing.
             children_template = extract_embedded_template(

--- a/tdom/types.py
+++ b/tdom/types.py
@@ -1,0 +1,145 @@
+import typing as t
+from collections.abc import Callable, Iterable, Sequence
+from decimal import Decimal
+from string.templatelib import Template
+
+from .protocols import HasHTMLDunder
+
+type FunctionComponent = Callable[..., Template]
+type FactoryComponent = Callable[..., ComponentObject]
+type ComponentInterpolationValue = FunctionComponent | FactoryComponent
+type ComponentObject = Callable[[], Template]
+
+
+type CommonNumberType = int | float | Decimal  # fractions.Fraction? #complex?
+
+type NormalTextInterpolationValue = (
+    None
+    | bool  # to support `showValue and value` idiom
+    | str
+    | HasHTMLDunder
+    | Template
+    | Iterable[NormalTextInterpolationValue]
+    | object
+)
+# Applies to both escapable raw text and raw text.
+type RawTextExactInterpolationValue = (
+    None
+    | bool  # to support `showValue and value` idiom
+    | str
+    | HasHTMLDunder
+    | object
+)
+# Applies to both escapable raw text and raw text.
+type RawTextInexactInterpolationValue = (
+    None
+    | bool  # to support `showValue and value` idiom
+    | str
+    | object
+)
+
+type ClassAttributeValueItem = None | str
+type ClassAttributeValue = (
+    ClassAttributeValueItem | Sequence[ClassAttributeValueItem] | dict[str, bool]
+)
+type StyleAttributeValue = None | str | dict[str, str | None]
+type AriaAttributeValueItem = None | object  # @TODO: Can we limit this?
+type AriaAttributeValue = None | dict[str, AriaAttributeValueItem]
+type DataAttributeValueItem = None | object  # @TODO: Can we limit this?
+type DataAttributeValue = None | dict[str, DataAttributeValueItem]
+type InterpolatedAttributeValue = None | object
+type TemplatedAttributeValue = None | str | object
+
+if t.TYPE_CHECKING:  # no native support for extra_items yet
+    SpreadAttribute = t.TypedDict(
+        "SpreadAttribute",
+        {
+            "class": t.NotRequired[ClassAttributeValue],
+            "style": t.NotRequired[StyleAttributeValue],
+            "aria": t.NotRequired[AriaAttributeValue],
+            "data": t.NotRequired[DataAttributeValue],
+        },
+        extra_items=InterpolatedAttributeValue,
+    )
+
+    # @NOTE: This map is meant to be used by tooling and could potentially
+    # be customized to match extensions made to the supported types.
+    # @TODO: Excludes format_spec interpretations, ie. ":callback",
+    # and builtin conversions, ie. "!r".
+    default_template_type_map = {
+        # Components
+        ComponentInterpolationValue: ComponentInterpolationValue,  # <{component}></{component}>
+        # Text types
+        NormalTextInterpolationValue: NormalTextInterpolationValue,  # <normal_tag>{normal_text}</normal_tag>
+        RawTextExactInterpolationValue: RawTextExactInterpolationValue,  # <raw_text_tag>{raw_text_exact}</raw_text_tag>
+        RawTextInexactInterpolationValue: RawTextInexactInterpolationValue,  # <raw_text_tag>{raw_text_inexact} literal text and/or more {raw_text_inexact}</raw_text_tag>
+        # Attribute types
+        InterpolatedAttributeValue: InterpolatedAttributeValue,  # <tag standard-attribute={interpolated_attribute_value}>
+        TemplatedAttributeValue: TemplatedAttributeValue,  # <tag standard-attribute="{templated_attribute_value} literal text and/or more {templated_attribute_value}">
+        ClassAttributeValue: ClassAttributeValue,  # <tag class={class_attribute_value}>
+        StyleAttributeValue: StyleAttributeValue,  # <tag style={style_attribute_value}>
+        AriaAttributeValue: AriaAttributeValue,  # <tag aria={aria_attribute_value}>
+        DataAttributeValue: DataAttributeValue,  # <tag data={data_attribute_value}>
+        SpreadAttribute: SpreadAttribute,  # <tag {spread_attribute}>
+    }
+
+
+type StrictNormalTextInterpolationValue = (
+    None
+    | bool  # to support `showValue and value` idiom
+    | str
+    | HasHTMLDunder
+    | Template
+    | Iterable[StrictNormalTextInterpolationValue]
+    | CommonNumberType
+)
+
+type StrictRawTextExactInterpolationValue = (
+    None
+    | bool  # to support `showValue and value` idiom
+    | str
+    | HasHTMLDunder
+    | CommonNumberType
+)
+
+type StrictRawTextInexactInterpolationValue = (
+    None
+    | bool  # to support `showValue and value` idiom
+    | str
+    | CommonNumberType
+)
+
+type StrictAriaAttributeValueItem = None | (str | bool)  # @TODO: Can we limit this?
+type StrictAriaAttributeValue = None | dict[str, StrictAriaAttributeValueItem]
+type StrictDataAttributeValueItem = None | (
+    str | bool | CommonNumberType
+)  # @TODO: Can we limit this?
+type StrictDataAttributeValue = None | dict[str, StrictDataAttributeValueItem]
+type StrictInterpolatedAttributeValue = None | (str | CommonNumberType)
+type StrictTemplatedAttributeValue = None | str | CommonNumberType
+if t.TYPE_CHECKING:  # no native support for extra_items yet
+    StrictSpreadAttribute = t.TypedDict(
+        "StrictSpreadAttribute",
+        {
+            "class": t.NotRequired[ClassAttributeValue],
+            "style": t.NotRequired[StyleAttributeValue],
+            "aria": t.NotRequired[StrictAriaAttributeValue],
+            "data": t.NotRequired[StrictDataAttributeValue],
+        },
+        extra_items=StrictInterpolatedAttributeValue,
+    )
+
+    # Some types can be made more strict usually by replacting `object` which
+    # would normally be run through `str()` with common numbers and forcing
+    # callers to cast everything else themselves with `!s` or `!r` or preformat
+    # values.  Ie. To catch this t'<div>{email_server}</div>'.
+    default_template_strict_type_map = default_template_type_map | {
+        NormalTextInterpolationValue: StrictNormalTextInterpolationValue,
+        RawTextExactInterpolationValue: StrictRawTextExactInterpolationValue,
+        RawTextInexactInterpolationValue: StrictRawTextInexactInterpolationValue,
+        InterpolatedAttributeValue: StrictInterpolatedAttributeValue,
+        TemplatedAttributeValue: StrictTemplatedAttributeValue,
+        AriaAttributeValue: StrictAriaAttributeValue,
+        DataAttributeValue: StrictDataAttributeValue,
+        SpreadAttribute: StrictSpreadAttribute,
+    }


### PR DESCRIPTION
This is just a **draft / concept** of a way we could specify supported types that tooling could use to give feedback to users about what they are plugging into `TDOM` templates.  This is sort of what I felt like we have been working towards:
- what is the structure of the templates -- `TNode`, `TAttribute`, `...`
- what values can be interpolated in the templates -- `default_template_type_map` (this thing)

Obviously having `object` all over the place isn't great so I tried to take a stab at a more strict set of types that would require other types to be preprocessed either before involving `Template` at all or with a conversion or format spec. 

I can imagine cases where you'd want to define some common types you are putting into templates and converting to strings yourself so there would probably be someway to extend this.