### PR TITLE
Component Process API Remix

### DIFF
--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -519,6 +519,7 @@ class IComponentProcessor(t.Protocol):
         component_callable: ComponentCallable,
         attrs: tuple[TAttribute, ...],
         component_template: Template,
+        provided_attrs: tuple[Attribute, ...] = (),
     ) -> ComponentObject | Template:
         """
         Process available component details into a queryable object or template.
@@ -539,6 +540,7 @@ class ComponentProcessor(IComponentProcessor):
         component_callable: ComponentCallable,
         attrs: tuple[TAttribute, ...],
         component_template: Template,
+        provided_attrs: tuple[Attribute, ...] = (),
     ) -> ComponentObject | Template:
         """
         Process available component details into a queryable object or template.
@@ -554,6 +556,7 @@ class ComponentProcessor(IComponentProcessor):
             get_callable_info(component_callable),
             _resolve_t_attrs(attrs, template.interpolations),
             children=component_template,
+            provided_attrs=provided_attrs,
         )
         return component_callable(**kwargs)
 

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -386,13 +386,24 @@ def _prep_component_kwargs(
     callable_info: CallableInfo,
     attrs: AttributesDict,
     children: Template,
+    provided_attrs: tuple[Attribute, ...] = (),
 ) -> AttributesDict:
+    """
+    Matchup kwargs from multiple sources to target the given callable.
+
+    The `provided_attrs` can be used by extensions that want to provide
+    kwargs even if they are not specified in a template.
+    """
     if callable_info.requires_positional:
         raise TypeError(
             "Component callables cannot have required positional arguments."
         )
 
     kwargs: AttributesDict = {}
+
+    for pattr_name, pattr_value in provided_attrs:
+        if pattr_name in callable_info.named_params or callable_info.kwargs:
+            kwargs[pattr_name] = pattr_value
 
     # Add all supported attributes
     for attr_name, attr_value in attrs.items():

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -387,6 +387,8 @@ def _prep_component_kwargs(
     attrs: AttributesDict,
     children: Template,
     provided_attrs: tuple[Attribute, ...] = (),
+    raise_on_requires_positional=True,
+    raise_on_missing=True,
 ) -> AttributesDict:
     """
     Matchup kwargs from multiple sources to target the given callable.
@@ -394,16 +396,14 @@ def _prep_component_kwargs(
     The `provided_attrs` can be used by extensions that want to provide
     kwargs even if they are not specified in a template.
     """
-    if callable_info.requires_positional:
+
+    # We can't know what kwarg to put here...
+    if raise_on_requires_positional and callable_info.requires_positional:
         raise TypeError(
             "Component callables cannot have required positional arguments."
         )
 
     kwargs: AttributesDict = {}
-
-    for pattr_name, pattr_value in provided_attrs:
-        if pattr_name in callable_info.named_params or callable_info.kwargs:
-            kwargs[pattr_name] = pattr_value
 
     # Add all supported attributes
     for attr_name, attr_value in attrs.items():
@@ -414,12 +414,20 @@ def _prep_component_kwargs(
     if "children" in callable_info.named_params or callable_info.kwargs:
         kwargs["children"] = children
 
+    # Add in provided attrs if they haven't been set already and are wanted.
+    for pattr_name, pattr_value in provided_attrs:
+        if pattr_name not in kwargs and (
+            pattr_name in callable_info.named_params or callable_info.kwargs
+        ):
+            kwargs[pattr_name] = pattr_value
+
     # Check to make sure we've fully satisfied the callable's requirements
-    missing = callable_info.required_named_params - kwargs.keys()
-    if missing:
-        raise TypeError(
-            f"Missing required parameters for component: {', '.join(missing)}"
-        )
+    if raise_on_missing:
+        missing = callable_info.required_named_params - kwargs.keys()
+        if missing:
+            raise TypeError(
+                f"Missing required parameters for component: {', '.join(missing)}"
+            )
 
     return kwargs
 
@@ -555,6 +563,8 @@ class ComponentProcessor(IComponentProcessor):
             _resolve_t_attrs(attrs, template.interpolations),
             children=component_template,
             provided_attrs=provided_attrs,
+            raise_on_requires_positional=True,
+            raise_on_missing=True,
         )
         res1 = component_callable(**kwargs)  # ty: ignore[call-top-callable]
         # This integration API seems a lot cleaner but we lose the ability for

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -574,7 +574,7 @@ class ComponentProcessor(IComponentProcessor):
         if isinstance(res1, Template):
             return res1, None
         elif callable(res1):
-            res2 = res1() # ty: ignore[call-top-callable]
+            res2 = res1()  # ty: ignore[call-top-callable]
             if isinstance(res2, Template):
                 # @TODO: It seems like we should not need this.
                 # Although our check against res2 doesn't seem to affect the

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -513,14 +513,13 @@ class IComponentProcessor(t.Protocol):
 
     def process(
         self,
-        # TODO: ? processor_api: IProcessor,
         template: Template,
         last_ctx: ProcessContext,
-        component_callable: ComponentCallable,
+        component_callable: t.Annotated[object, ComponentCallable],
         attrs: tuple[TAttribute, ...],
         component_template: Template,
         provided_attrs: tuple[Attribute, ...] = (),
-    ) -> ComponentObject | Template:
+    ) -> tuple[Template, ComponentObject | None]:
         """
         Process available component details into a queryable object or template.
         """
@@ -534,14 +533,13 @@ class ComponentProcessor(IComponentProcessor):
 
     def process(
         self,
-        # @TODO: ? processor_api: IProcessor,
         template: Template,
         last_ctx: ProcessContext,
-        component_callable: ComponentCallable,
+        component_callable: t.Annotated[object, ComponentCallable],
         attrs: tuple[TAttribute, ...],
         component_template: Template,
         provided_attrs: tuple[Attribute, ...] = (),
-    ) -> ComponentObject | Template:
+    ) -> tuple[Template, ComponentObject | None]:
         """
         Process available component details into a queryable object or template.
 
@@ -558,7 +556,28 @@ class ComponentProcessor(IComponentProcessor):
             children=component_template,
             provided_attrs=provided_attrs,
         )
-        return component_callable(**kwargs)
+        res1 = component_callable(**kwargs)  # ty: ignore[call-top-callable]
+        # This integration API seems a lot cleaner but we lose the ability for
+        # component_object.__call__ to be wrapped in any sort of context setting
+        # mechanism provided by the class, but maybe that's ok?  It could be
+        # cached on the instance although that is kind of gross.
+        if isinstance(res1, Template):
+            return res1, None
+        elif callable(res1):
+            res2 = res1() # ty: ignore[call-top-callable]
+            if isinstance(res2, Template):
+                # @TODO: It seems like we should not need this.
+                # Although our check against res2 doesn't seem to affect the
+                # return value of res1.
+                return res2, t.cast(ComponentObject, res1)
+            else:
+                raise TypeError(
+                    f"Component object must return Template when called: {type(res2)}"
+                )
+        else:
+            raise TypeError(
+                f"Component callable must return Template or Callable: {type(res1)}"
+            )
 
 
 class ITemplateProcessor(t.Protocol):
@@ -736,6 +755,33 @@ class TemplateProcessor(ITemplateProcessor):
             return attrs_str
         return ""
 
+    def _extract_component_template(
+        self,
+        template: Template,
+        attrs: tuple[TAttribute, ...],
+        start_i_index: int,
+        end_i_index: int | None,
+        check_callables: bool = True,
+    ) -> Template:
+        body_start_s_index = (
+            start_i_index
+            + 1
+            + len([1 for attr in attrs if not isinstance(attr, TLiteralAttribute)])
+        )
+        if start_i_index != end_i_index and end_i_index is not None:
+            # @TODO: We should do this during parsing.
+            if (
+                check_callables
+                and template.interpolations[start_i_index].value
+                != template.interpolations[end_i_index].value
+            ):
+                raise TypeError(
+                    "Component callable in start tag must match component callable in end tag."
+                )
+            return extract_embedded_template(template, body_start_s_index, end_i_index)
+        else:
+            return t""
+
     def _process_component(
         self,
         template: Template,
@@ -747,43 +793,15 @@ class TemplateProcessor(ITemplateProcessor):
         """
         Invoke a component and process the result into a string.
         """
-        body_start_s_index = (
-            start_i_index
-            + 1
-            + len([1 for attr in attrs if not isinstance(attr, TLiteralAttribute)])
+        children_template = self._extract_component_template(
+            template, attrs, start_i_index, end_i_index, check_callables=True
         )
-        start_i = template.interpolations[start_i_index]
-        component_callable = t.cast(ComponentCallable, start_i.value)
-        if start_i_index != end_i_index and end_i_index is not None:
-            # @TODO: We should do this during parsing.
-            children_template = extract_embedded_template(
-                template, body_start_s_index, end_i_index
-            )
-            if component_callable != template.interpolations[end_i_index].value:
-                raise TypeError(
-                    "Component callable in start tag must match component callable in end tag."
-                )
-        else:
-            children_template = t""
-
-        result_t = self.component_processor_api.process(
+        component_callable = template.interpolations[start_i_index].value
+        result_t, component_object = self.component_processor_api.process(
             template, last_ctx, component_callable, attrs, children_template
         )
-
-        if (
-            result_t is not None
-            and not isinstance(result_t, Template)
-            and callable(result_t)
-        ):
-            component_obj = t.cast(ComponentObject, result_t)  # ty: ignore[redundant-cast]
-            result_t = component_obj()
-        else:
-            component_obj = None
-
-        if isinstance(result_t, Template):
-            return self._process_template(result_t, last_ctx)
-        else:
-            raise TypeError(f"Unknown component return value: {type(result_t)}")
+        assert isinstance(component_object, object)
+        return self._process_template(result_t, last_ctx)
 
     def _process_raw_texts(
         self,

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -546,6 +546,10 @@ class ComponentProcessor(IComponentProcessor):
         Default strategy just uses `_prep_component_kwargs` for `kwargs`
         injecting `children` if asked.
         """
+        if not callable(component_callable):
+            raise TypeError(
+                f"Component callable must be callable: {type(component_callable)}"
+            )
         kwargs = _prep_component_kwargs(
             get_callable_info(component_callable),
             _resolve_t_attrs(attrs, template.interpolations),

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -527,9 +527,9 @@ class IComponentProcessor(t.Protocol):
         attrs: tuple[TAttribute, ...],
         component_template: Template,
         provided_attrs: tuple[Attribute, ...] = (),
-    ) -> tuple[Template, ComponentObject | None]:
+    ) -> Template:
         """
-        Process available component details into a queryable object or template.
+        Process available component details into a Template.
         """
         ...
 
@@ -547,12 +547,29 @@ class ComponentProcessor(IComponentProcessor):
         attrs: tuple[TAttribute, ...],
         component_template: Template,
         provided_attrs: tuple[Attribute, ...] = (),
-    ) -> tuple[Template, ComponentObject | None]:
+    ) -> Template:
         """
-        Process available component details into a queryable object or template.
+        Process available component details into a Template.
 
-        Default strategy just uses `_prep_component_kwargs` for `kwargs`
-        injecting `children` if asked.
+        There are two general "styles" supported:
+
+        1. FunctionComponent
+
+        Calling `component_callable` with the prepared kwargs should
+        return a `Template`.
+
+        The primary purpose of this style is to support
+        using a normal function as a component.
+
+        2. FactoryComponent
+
+        Calling `component_callable` with the prepared kwargs should
+        return another `Callable` which when called with no arguments should
+        return a `Template`.
+
+        The primary purpose of this style is to support
+        using a `dataclass` with `def __call__(self) -> Template` as a
+        component.
         """
         if not callable(component_callable):
             raise TypeError(
@@ -567,19 +584,12 @@ class ComponentProcessor(IComponentProcessor):
             raise_on_missing=True,
         )
         res1 = component_callable(**kwargs)  # ty: ignore[call-top-callable]
-        # This integration API seems a lot cleaner but we lose the ability for
-        # component_object.__call__ to be wrapped in any sort of context setting
-        # mechanism provided by the class, but maybe that's ok?  It could be
-        # cached on the instance although that is kind of gross.
         if isinstance(res1, Template):
-            return res1, None
+            return res1
         elif callable(res1):
             res2 = res1()  # ty: ignore[call-top-callable]
             if isinstance(res2, Template):
-                # @TODO: It seems like we should not need this.
-                # Although our check against res2 doesn't seem to affect the
-                # return value of res1.
-                return res2, t.cast(ComponentObject, res1)
+                return res2
             else:
                 raise TypeError(
                     f"Component object must return Template when called: {type(res2)}"
@@ -807,10 +817,9 @@ class TemplateProcessor(ITemplateProcessor):
             template, attrs, start_i_index, end_i_index, check_callables=True
         )
         component_callable = template.interpolations[start_i_index].value
-        result_t, component_object = self.component_processor_api.process(
+        result_t = self.component_processor_api.process(
             template, last_ctx, component_callable, attrs, children_template
         )
-        assert isinstance(component_object, object)
         return self._process_template(result_t, last_ctx)
 
     def _process_raw_texts(

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -497,6 +497,52 @@ class CachedTemplateParserProxy(TemplateParserProxy):
         return self._to_tnode(CachableTemplate(template))
 
 
+class IComponentProcessor(t.Protocol):
+    """Isolate component processing to allow for replacement."""
+
+    def process(
+        self,
+        # TODO: ? processor_api: IProcessor,
+        template: Template,
+        last_ctx: ProcessContext,
+        component_callable: ComponentCallable,
+        attrs: tuple[TAttribute, ...],
+        component_template: Template,
+    ) -> ComponentObject | Template:
+        """
+        Process available component details into a queryable object or template.
+        """
+        ...
+
+
+class ComponentProcessor(IComponentProcessor):
+    """
+    Default component processor.
+    """
+
+    def process(
+        self,
+        # @TODO: ? processor_api: IProcessor,
+        template: Template,
+        last_ctx: ProcessContext,
+        component_callable: ComponentCallable,
+        attrs: tuple[TAttribute, ...],
+        component_template: Template,
+    ) -> ComponentObject | Template:
+        """
+        Process available component details into a queryable object or template.
+
+        Default strategy just uses `_prep_component_kwargs` for `kwargs`
+        injecting `children` if asked.
+        """
+        kwargs = _prep_component_kwargs(
+            get_callable_info(component_callable),
+            _resolve_t_attrs(attrs, template.interpolations),
+            children=component_template,
+        )
+        return component_callable(**kwargs)
+
+
 class ITemplateProcessor(t.Protocol):
     def process(self, root_template: Template, assume_ctx: ProcessContext) -> str: ...
 
@@ -504,6 +550,10 @@ class ITemplateProcessor(t.Protocol):
 @dataclass(frozen=True)
 class TemplateProcessor(ITemplateProcessor):
     parser_api: ITemplateParserProxy = field(default_factory=CachedTemplateParserProxy)
+
+    component_processor_api: IComponentProcessor = field(
+        default_factory=ComponentProcessor
+    )
 
     escape_html_text: Callable = default_escape_html_text
 
@@ -698,16 +748,10 @@ class TemplateProcessor(ITemplateProcessor):
         else:
             children_template = t""
 
-        if not callable(component_callable):
-            raise TypeError("Component callable must be callable.")
-
-        kwargs = _prep_component_kwargs(
-            get_callable_info(component_callable),
-            _resolve_t_attrs(attrs, template.interpolations),
-            children=children_template,
+        result_t = self.component_processor_api.process(
+            template, last_ctx, component_callable, attrs, children_template
         )
 
-        result_t = component_callable(**kwargs)
         if (
             result_t is not None
             and not isinstance(result_t, Template)

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -393,8 +393,26 @@ def _prep_component_kwargs(
     """
     Matchup kwargs from multiple sources to target the given callable.
 
-    The `provided_attrs` can be used by extensions that want to provide
-    kwargs even if they are not specified in a template.
+    `provided_attrs`:
+        These can be used by extensions that want to provide
+        attrs even if they are not specified in the component's `attrs` in
+        the template. If an attribute with the same name is provided in
+        `attrs` then it takes priority over entries in `provided_attrs`.
+        @NOTE: These will be injected into any component with `**kwargs`
+        in their signature unless provided already by `attrs`.
+
+    `raise_on_requires_positional`:
+        Optionally check and raise `TypeError` if the `callable_info` requires
+        positional arguments which we cannot fulfill normally.
+        An exception might not be desired if the caller will finish preparing
+        the arguments after this call.
+
+    `raise_on_missing`:
+        Optionally check and raise `TypeError` if we are not able to fulfill all
+        the arguments the `callable_info` expects since in the common case this
+        raise an exception whose cause might not be clear.
+        An exception might not be desired if the caller will finish preparing
+        the arguments after this call.
     """
 
     # We can't know what kwarg to put here...

--- a/tdom/processor_extension_test.py
+++ b/tdom/processor_extension_test.py
@@ -6,7 +6,6 @@ from string.templatelib import Template
 from .processor import (
     Attribute,
     ComponentCallable,
-    ComponentObject,
     ComponentProcessor,
     IComponentProcessor,
     ProcessContext,
@@ -102,7 +101,7 @@ class TestComponentProcessor:
             attrs: tuple[TAttribute, ...],
             component_template: Template,
             provided_attrs: tuple[Attribute, ...] = (),
-        ) -> tuple[Template, ComponentObject | None]:
+        ) -> Template:
             from inspect import isclass
 
             system_ctx = SystemCtx.get()
@@ -112,28 +111,12 @@ class TestComponentProcessor:
                 and t.is_protocol(component_callable)
                 and component_callable in system_ctx.components
             ):
-                # Use the protocol to get the concrete component factory.
-                # @NOTE: This is using the contextvars.ContextVar to
-                # get this information but maybe in the future we'd have
-                # a way to get ctx directly from a parameter.
                 component_callable = system_ctx.components[component_callable]
 
-            # Also pass in system provided attributes to EVERY
-            # component (but it will only be used during the call if it needed.
-            # @NOTE: This is using the contextvars.ContextVar to
-            # get this information but maybe in the future we'd have
-            # a way to get ctx directly from a parameter.
             if system_ctx is not None:
                 system_attrs = (("request", system_ctx.request),)
                 provided_attrs = provided_attrs + system_attrs
 
-            # @NOTE: We mostly just put the correct values in the right places
-            # to perform the default component processing.
-            # - `component_callable` is now the actual concrete implementation
-            # - `provided_attrs` now has attrs that might not be in the template
-            # So we can just wrap the default processor and let it do all the
-            # work. BUT... if we wanted to just replace the invocation we could
-            # do that and just return the correct thing ourselves.
             return self.default_component_processor_api.process(
                 template=template,
                 last_ctx=last_ctx,

--- a/tdom/processor_extension_test.py
+++ b/tdom/processor_extension_test.py
@@ -1,11 +1,9 @@
-import typing as t
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from string.templatelib import Template
 
 from .processor import (
     Attribute,
-    ComponentCallable,
     ComponentProcessor,
     IComponentProcessor,
     ProcessContext,
@@ -14,81 +12,36 @@ from .processor import (
 from .tnodes import TAttribute
 
 
-class ISimpleRequest(t.Protocol):
-    def make_url(self, path: str) -> str: ...
+@dataclass(frozen=True, slots=True)
+class AppState:
+    theme_class: str
 
 
-@dataclass()
-class SystemState:
-    request: ISimpleRequest
-    components: dict[object, ComponentCallable] = field(
-        default_factory=dict
-    )  # t.Type[t.Protocol]
-
-
-SystemCtx: ContextVar[SystemState | None] = ContextVar("SystemCtx", default=None)
+AppStateCtx: ContextVar[AppState | None] = ContextVar("AppStateCtx", default=None)
 
 
 class TestComponentProcessor:
     @dataclass
-    class SimpleRequest(ISimpleRequest):
-        scheme: str
-        host: str
-
-        def make_url(self, path: str) -> str:
-            # @NOTE: Don't actually make URLs this way, this is just an example.
-            return f"{self.scheme}://{self.host}/{path.lstrip('/')}"
-
-    class IHeader(t.Protocol):
+    class Body:
         children: Template
-        hdr_class: str
 
-        def __call__(self) -> Template: ...
+        def __call__(self) -> Template:
+            return t"<body>{self.children}</body>"
 
     @dataclass
-    class Header(IHeader):
+    class Header:
         children: Template
+
+        app_state: AppState
 
         hdr_class: str = "hdr"
 
         def __call__(self) -> Template:
-            return t"<div class={self.hdr_class}>{self.children}</div>"
-
-    class INav(t.Protocol):
-        request: ISimpleRequest
-
-        links: tuple[tuple[str, str], ...]
-
-        def __call__(self) -> Template: ...
+            return t"<div class={self.hdr_class} class={self.app_state.theme_class}>{self.children}</div>"
 
     @dataclass
-    class Nav(INav):
-        request: ISimpleRequest
-
-        links: tuple[tuple[str, str], ...] = ()
-
-        nav_class: str = "nav"
-
-        def _make_nav_links(self) -> list[Template]:
-            return [
-                t"<a href={self.request.make_url(href)}>{label}</a>"
-                for label, href in self.links
-            ]
-
-        def __call__(self) -> Template:
-            return t"<div class={self.nav_class}>{self._make_nav_links()}</div>"
-
-    @dataclass
-    class Logo:  # NO DI / NO Protocol
-        logo_fallback: str = "LOGO"
-
-        logo_class: str = "logo"
-
-        def __call__(self) -> Template:
-            return t"<span class={self.logo_class}>{self.logo_fallback}</span>"
-
-    @dataclass
-    class SystemComponentProcessor(IComponentProcessor):
+    class AppStateComponentProcessor(IComponentProcessor):
+        # Delegate to the default processor to reuse code.
         default_component_processor_api: IComponentProcessor = field(
             default_factory=ComponentProcessor
         )
@@ -102,50 +55,49 @@ class TestComponentProcessor:
             component_template: Template,
             provided_attrs: tuple[Attribute, ...] = (),
         ) -> Template:
-            from inspect import isclass
-
-            system_ctx = SystemCtx.get()
-            if (
-                system_ctx is not None
-                and isclass(component_callable)
-                and t.is_protocol(component_callable)
-                and component_callable in system_ctx.components
-            ):
-                component_callable = system_ctx.components[component_callable]
-
-            if system_ctx is not None:
-                system_attrs = (("request", system_ctx.request),)
-                provided_attrs = provided_attrs + system_attrs
-
+            # For now we just make the app state available to EVERY component
+            # a smarter strategy would be to only include it if asked via
+            # the callable's signature or even the callable's typehints.
+            # But for a test this is OK.
+            app_state = AppStateCtx.get()
+            extended_attrs = provided_attrs + (("app_state", app_state),)
             return self.default_component_processor_api.process(
                 template=template,
                 last_ctx=last_ctx,
                 component_callable=component_callable,
                 attrs=attrs,
                 component_template=component_template,
-                provided_attrs=provided_attrs,
+                provided_attrs=extended_attrs,
             )
 
-    def test_replacement(self):
-        sys_comp_processor = self.SystemComponentProcessor()
+    def _make_html(self):
+        app_state_processor = self.AppStateComponentProcessor()
+        tp = TemplateProcessor(component_processor_api=app_state_processor)
+        assume_ctx = ProcessContext()
 
-        tp = TemplateProcessor(component_processor_api=sys_comp_processor)
+        def _html(template: Template, app_state: AppState | None = None) -> str:
+            if app_state is None:
+                app_state = AppState(theme_class="theme-default")
+            with AppStateCtx.set(app_state):
+                return tp.process(template, assume_ctx=assume_ctx)
 
-        # Mapping established beforehand.
-        components: dict[object, ComponentCallable] = {  # t.Type[t.Protocol]
-            self.IHeader: self.Header,
-            self.INav: self.Nav,
-        }
-        current_request = self.SimpleRequest(scheme="https", host="www.example.com")
-        with SystemCtx.set(SystemState(components=components, request=current_request)):
-            links = [("Home", "/"), ("About", "/about")]
-            header_t = t"<{self.IHeader}><{self.Logo} /><{self.INav} links={links} /></{self.IHeader}>"
-            assert tp.process(header_t, assume_ctx=ProcessContext()) == (
-                '<div class="hdr">'
-                '<span class="logo">LOGO</span>'
-                '<div class="nav">'
-                '<a href="https://www.example.com/">Home</a>'
-                '<a href="https://www.example.com/about">About</a>'
-                "</div>"
-                "</div>"
-            )
+        return _html
+
+    def test_injected_app_state(self):
+        name = "App"
+        body_t = (
+            t"<{self.Body}><{self.Header}><h1>{name}</h1></{self.Header}></{self.Body}>"
+        )
+        html = self._make_html()
+        assert (
+            html(body_t, app_state=None)
+            == '<body><div class="hdr theme-default"><h1>App</h1></div></body>'
+        )
+        assert (
+            html(body_t, app_state=AppState(theme_class="theme-spring"))
+            == '<body><div class="hdr theme-spring"><h1>App</h1></div></body>'
+        )
+        assert (
+            html(body_t, app_state=None)
+            == '<body><div class="hdr theme-default"><h1>App</h1></div></body>'
+        )

--- a/tdom/processor_extension_test.py
+++ b/tdom/processor_extension_test.py
@@ -1,0 +1,168 @@
+import typing as t
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from string.templatelib import Template
+
+from .processor import (
+    Attribute,
+    ComponentCallable,
+    ComponentObject,
+    ComponentProcessor,
+    IComponentProcessor,
+    ProcessContext,
+    TemplateProcessor,
+)
+from .tnodes import TAttribute
+
+
+class ISimpleRequest(t.Protocol):
+    def make_url(self, path: str) -> str: ...
+
+
+@dataclass()
+class SystemState:
+    request: ISimpleRequest
+    components: dict[object, ComponentCallable] = field(
+        default_factory=dict
+    )  # t.Type[t.Protocol]
+
+
+SystemCtx: ContextVar[SystemState | None] = ContextVar("SystemCtx", default=None)
+
+
+class TestComponentProcessor:
+    @dataclass
+    class SimpleRequest(ISimpleRequest):
+        scheme: str
+        host: str
+
+        def make_url(self, path: str) -> str:
+            # @NOTE: Don't actually make URLs this way, this is just an example.
+            return f"{self.scheme}://{self.host}/{path.lstrip('/')}"
+
+    class IHeader(t.Protocol):
+        children: Template
+        hdr_class: str
+
+        def __call__(self) -> Template: ...
+
+    @dataclass
+    class Header(IHeader):
+        children: Template
+
+        hdr_class: str = "hdr"
+
+        def __call__(self) -> Template:
+            return t"<div class={self.hdr_class}>{self.children}</div>"
+
+    class INav(t.Protocol):
+        request: ISimpleRequest
+
+        links: tuple[tuple[str, str], ...]
+
+        def __call__(self) -> Template: ...
+
+    @dataclass
+    class Nav(INav):
+        request: ISimpleRequest
+
+        links: tuple[tuple[str, str], ...] = ()
+
+        nav_class: str = "nav"
+
+        def _make_nav_links(self) -> list[Template]:
+            return [
+                t"<a href={self.request.make_url(href)}>{label}</a>"
+                for label, href in self.links
+            ]
+
+        def __call__(self) -> Template:
+            return t"<div class={self.nav_class}>{self._make_nav_links()}</div>"
+
+    @dataclass
+    class Logo:  # NO DI / NO Protocol
+        logo_fallback: str = "LOGO"
+
+        logo_class: str = "logo"
+
+        def __call__(self) -> Template:
+            return t"<span class={self.logo_class}>{self.logo_fallback}</span>"
+
+    @dataclass
+    class SystemComponentProcessor(IComponentProcessor):
+        default_component_processor_api: IComponentProcessor = field(
+            default_factory=ComponentProcessor
+        )
+
+        def process(
+            self,
+            template: Template,
+            last_ctx: ProcessContext,
+            component_callable: object,
+            attrs: tuple[TAttribute, ...],
+            component_template: Template,
+            provided_attrs: tuple[Attribute, ...] = (),
+        ) -> tuple[Template, ComponentObject | None]:
+            from inspect import isclass
+
+            system_ctx = SystemCtx.get()
+            if (
+                system_ctx is not None
+                and isclass(component_callable)
+                and t.is_protocol(component_callable)
+                and component_callable in system_ctx.components
+            ):
+                # Use the protocol to get the concrete component factory.
+                # @NOTE: This is using the contextvars.ContextVar to
+                # get this information but maybe in the future we'd have
+                # a way to get ctx directly from a parameter.
+                component_callable = system_ctx.components[component_callable]
+
+            # Also pass in system provided attributes to EVERY
+            # component (but it will only be used during the call if it needed.
+            # @NOTE: This is using the contextvars.ContextVar to
+            # get this information but maybe in the future we'd have
+            # a way to get ctx directly from a parameter.
+            if system_ctx is not None:
+                system_attrs = (("request", system_ctx.request),)
+                provided_attrs = provided_attrs + system_attrs
+
+            # @NOTE: We mostly just put the correct values in the right places
+            # to perform the default component processing.
+            # - `component_callable` is now the actual concrete implementation
+            # - `provided_attrs` now has attrs that might not be in the template
+            # So we can just wrap the default processor and let it do all the
+            # work. BUT... if we wanted to just replace the invocation we could
+            # do that and just return the correct thing ourselves.
+            return self.default_component_processor_api.process(
+                template=template,
+                last_ctx=last_ctx,
+                component_callable=component_callable,
+                attrs=attrs,
+                component_template=component_template,
+                provided_attrs=provided_attrs,
+            )
+
+    def test_replacement(self):
+        sys_comp_processor = self.SystemComponentProcessor()
+
+        tp = TemplateProcessor(component_processor_api=sys_comp_processor)
+
+        # Mapping established beforehand.
+        components: dict[object, ComponentCallable] = {  # t.Type[t.Protocol]
+            self.IHeader: self.Header,
+            self.INav: self.Nav,
+        }
+        current_request = self.SimpleRequest(scheme="https", host="www.example.com")
+        with SystemCtx.set(SystemState(components=components, request=current_request)):
+            links = [("Home", "/"), ("About", "/about")]
+            header_t = t"<{self.IHeader}><{self.Logo} /><{self.INav} links={links} /></{self.IHeader}>"
+            assert tp.process(header_t, assume_ctx=ProcessContext()) == (
+                '<div class="hdr">'
+                '<span class="logo">LOGO</span>'
+                '<div class="nav">'
+                '<a href="https://www.example.com/">Home</a>'
+                '<a href="https://www.example.com/about">About</a>'
+                "</div>"
+                "</div>"
+            )

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -23,7 +23,6 @@ from .processor import (
     TemplateParserProxy,
     TemplateProcessor,
     _make_default_template_processor,
-    make_ctx,
 )
 from .processor import (
     _prep_component_kwargs as prep_component_kwargs,
@@ -1979,7 +1978,7 @@ class TestComponentProcessor:
         with SystemCtx.set(SystemState(components=components, request=current_request)):
             links = [("Home", "/"), ("About", "/about")]
             header_t = t"<{self.IHeader}><{self.Logo} /><{self.INav} links={links} /></{self.IHeader}>"
-            assert tp.process(header_t) == (
+            assert tp.process(header_t, assume_ctx=ProcessContext()) == (
                 '<div class="hdr">'
                 '<span class="logo">LOGO</span>'
                 '<div class="nav">'

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -1835,6 +1835,7 @@ class TestComponentErrors:
 
 @dataclass()
 class SystemState:
+    request: ISimpleRequest
     components: dict[object, ComponentCallable] = field(
         default_factory=dict
     )  # t.Type[t.Protocol]
@@ -1843,7 +1844,20 @@ class SystemState:
 SystemCtx: ContextVar[SystemState | None] = ContextVar("SystemCtx", default=None)
 
 
+class ISimpleRequest(t.Protocol):
+    def make_url(self, path: str) -> str: ...
+
+
 class TestComponentProcessor:
+    @dataclass
+    class SimpleRequest(ISimpleRequest):
+        scheme: str
+        host: str
+
+        def make_url(self, path: str) -> str:
+            # @NOTE: Don't actually make URLs this way, this is just an example.
+            return f"{self.scheme}://{self.host}/{path.lstrip('/')}"
+
     class IHeader(t.Protocol):
         children: Template
         hdr_class: str
@@ -1860,18 +1874,25 @@ class TestComponentProcessor:
             return t"<div class={self.hdr_class}>{self.children}</div>"
 
     class INav(t.Protocol):
+        request: ISimpleRequest
+
         links: tuple[tuple[str, str], ...]
 
         def __call__(self) -> Template: ...
 
     @dataclass
     class Nav(INav):
+        request: ISimpleRequest
+
         links: tuple[tuple[str, str], ...] = ()
 
         nav_class: str = "nav"
 
         def _make_nav_links(self) -> list[Template]:
-            return [t"<a href={href}>{label}</a>" for label, href in self.links]
+            return [
+                t"<a href={self.request.make_url(href)}>{label}</a>"
+                for label, href in self.links
+            ]
 
         def __call__(self) -> Template:
             return t"<div class={self.nav_class}>{self._make_nav_links()}</div>"
@@ -1909,7 +1930,28 @@ class TestComponentProcessor:
                 and t.is_protocol(component_callable)
                 and component_callable in system_ctx.components
             ):
+                # Use the protocol to get the concrete component factory.
+                # @NOTE: This is using the contextvars.ContextVar to
+                # get this information but maybe in the future we'd have
+                # a way to get ctx directly from a parameter.
                 component_callable = system_ctx.components[component_callable]
+
+            # Also pass in system provided attributes to EVERY
+            # component (but it will only be used during the call if it needed.
+            # @NOTE: This is using the contextvars.ContextVar to
+            # get this information but maybe in the future we'd have
+            # a way to get ctx directly from a parameter.
+            if system_ctx is not None:
+                system_attrs = (("request", system_ctx.request),)
+                provided_attrs = provided_attrs + system_attrs
+
+            # @NOTE: We mostly just put the correct values in the right places
+            # to perform the default component processing.
+            # - `component_callable` is now the actual concrete implementation
+            # - `provided_attrs` now has attrs that might not be in the template
+            # So we can just wrap the default processor and let it do all the
+            # work. BUT... if we wanted to just replace the invocation we could
+            # do that and just return the correct thing ourselves.
             return self.default_component_processor_api.process(
                 template=template,
                 last_ctx=last_ctx,
@@ -1929,11 +1971,18 @@ class TestComponentProcessor:
             self.IHeader: self.Header,
             self.INav: self.Nav,
         }
-        with SystemCtx.set(SystemState(components=components)):
+        current_request = self.SimpleRequest(scheme="https", host="www.example.com")
+        with SystemCtx.set(SystemState(components=components, request=current_request)):
             links = [("Home", "/"), ("About", "/about")]
             header_t = t"<{self.IHeader}><{self.Logo} /><{self.INav} links={links} /></{self.IHeader}>"
             assert tp.process(header_t) == (
-                '<div class="hdr"><span class="logo">LOGO</span><div class="nav"><a href="/">Home</a><a href="/about">About</a></div></div>'
+                '<div class="hdr">'
+                '<span class="logo">LOGO</span>'
+                '<div class="nav">'
+                '<a href="https://www.example.com/">Home</a>'
+                '<a href="https://www.example.com/about">About</a>'
+                "</div>"
+                "</div>"
             )
 
 

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -1,8 +1,7 @@
 import datetime
 import typing as t
 from collections.abc import Callable
-from contextvars import ContextVar
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from itertools import chain, product
 from string.templatelib import Template
 
@@ -13,12 +12,7 @@ from markupsafe import escape as markupsafe_escape
 from .callables import get_callable_info
 from .escaping import escape_html_text
 from .processor import (
-    Attribute,
     CachedTemplateParserProxy,
-    ComponentCallable,
-    ComponentObject,
-    ComponentProcessor,
-    IComponentProcessor,
     ProcessContext,
     TemplateParserProxy,
     TemplateProcessor,
@@ -28,7 +22,6 @@ from .processor import (
     _prep_component_kwargs as prep_component_kwargs,
 )
 from .protocols import HasHTMLDunder
-from .tnodes import TAttribute
 
 processor_api = _make_default_template_processor(
     parser_api=TemplateParserProxy(),  # do not use cache
@@ -1834,159 +1827,6 @@ class TestComponentErrors:
             TypeError, match="Component object must return Template when called:"
         ):
             _ = html(t"<{BadFactoryComp}>Hello</{BadFactoryComp}>")
-
-
-@dataclass()
-class SystemState:
-    request: ISimpleRequest
-    components: dict[object, ComponentCallable] = field(
-        default_factory=dict
-    )  # t.Type[t.Protocol]
-
-
-SystemCtx: ContextVar[SystemState | None] = ContextVar("SystemCtx", default=None)
-
-
-class ISimpleRequest(t.Protocol):
-    def make_url(self, path: str) -> str: ...
-
-
-class TestComponentProcessor:
-    @dataclass
-    class SimpleRequest(ISimpleRequest):
-        scheme: str
-        host: str
-
-        def make_url(self, path: str) -> str:
-            # @NOTE: Don't actually make URLs this way, this is just an example.
-            return f"{self.scheme}://{self.host}/{path.lstrip('/')}"
-
-    class IHeader(t.Protocol):
-        children: Template
-        hdr_class: str
-
-        def __call__(self) -> Template: ...
-
-    @dataclass
-    class Header(IHeader):
-        children: Template
-
-        hdr_class: str = "hdr"
-
-        def __call__(self) -> Template:
-            return t"<div class={self.hdr_class}>{self.children}</div>"
-
-    class INav(t.Protocol):
-        request: ISimpleRequest
-
-        links: tuple[tuple[str, str], ...]
-
-        def __call__(self) -> Template: ...
-
-    @dataclass
-    class Nav(INav):
-        request: ISimpleRequest
-
-        links: tuple[tuple[str, str], ...] = ()
-
-        nav_class: str = "nav"
-
-        def _make_nav_links(self) -> list[Template]:
-            return [
-                t"<a href={self.request.make_url(href)}>{label}</a>"
-                for label, href in self.links
-            ]
-
-        def __call__(self) -> Template:
-            return t"<div class={self.nav_class}>{self._make_nav_links()}</div>"
-
-    @dataclass
-    class Logo:  # NO DI / NO Protocol
-        logo_fallback: str = "LOGO"
-
-        logo_class: str = "logo"
-
-        def __call__(self) -> Template:
-            return t"<span class={self.logo_class}>{self.logo_fallback}</span>"
-
-    @dataclass
-    class SystemComponentProcessor(IComponentProcessor):
-        default_component_processor_api: IComponentProcessor = field(
-            default_factory=ComponentProcessor
-        )
-
-        def process(
-            self,
-            template: Template,
-            last_ctx: ProcessContext,
-            component_callable: object,
-            attrs: tuple[TAttribute, ...],
-            component_template: Template,
-            provided_attrs: tuple[Attribute, ...] = (),
-        ) -> tuple[Template, ComponentObject | None]:
-            from inspect import isclass
-
-            system_ctx = SystemCtx.get()
-            if (
-                system_ctx is not None
-                and isclass(component_callable)
-                and t.is_protocol(component_callable)
-                and component_callable in system_ctx.components
-            ):
-                # Use the protocol to get the concrete component factory.
-                # @NOTE: This is using the contextvars.ContextVar to
-                # get this information but maybe in the future we'd have
-                # a way to get ctx directly from a parameter.
-                component_callable = system_ctx.components[component_callable]
-
-            # Also pass in system provided attributes to EVERY
-            # component (but it will only be used during the call if it needed.
-            # @NOTE: This is using the contextvars.ContextVar to
-            # get this information but maybe in the future we'd have
-            # a way to get ctx directly from a parameter.
-            if system_ctx is not None:
-                system_attrs = (("request", system_ctx.request),)
-                provided_attrs = provided_attrs + system_attrs
-
-            # @NOTE: We mostly just put the correct values in the right places
-            # to perform the default component processing.
-            # - `component_callable` is now the actual concrete implementation
-            # - `provided_attrs` now has attrs that might not be in the template
-            # So we can just wrap the default processor and let it do all the
-            # work. BUT... if we wanted to just replace the invocation we could
-            # do that and just return the correct thing ourselves.
-            return self.default_component_processor_api.process(
-                template=template,
-                last_ctx=last_ctx,
-                component_callable=component_callable,
-                attrs=attrs,
-                component_template=component_template,
-                provided_attrs=provided_attrs,
-            )
-
-    def test_replacement(self):
-        sys_comp_processor = self.SystemComponentProcessor()
-
-        tp = TemplateProcessor(component_processor_api=sys_comp_processor)
-
-        # Mapping established beforehand.
-        components: dict[object, ComponentCallable] = {  # t.Type[t.Protocol]
-            self.IHeader: self.Header,
-            self.INav: self.Nav,
-        }
-        current_request = self.SimpleRequest(scheme="https", host="www.example.com")
-        with SystemCtx.set(SystemState(components=components, request=current_request)):
-            links = [("Home", "/"), ("About", "/about")]
-            header_t = t"<{self.IHeader}><{self.Logo} /><{self.INav} links={links} /></{self.IHeader}>"
-            assert tp.process(header_t, assume_ctx=ProcessContext()) == (
-                '<div class="hdr">'
-                '<span class="logo">LOGO</span>'
-                '<div class="nav">'
-                '<a href="https://www.example.com/">Home</a>'
-                '<a href="https://www.example.com/about">About</a>'
-                "</div>"
-                "</div>"
-            )
 
 
 def test_integration_basic():

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -1816,7 +1816,9 @@ class TestComponentErrors:
         def BadFunctionComp(children: Template):
             return bad_value
 
-        with pytest.raises(TypeError, match="Unknown component return value:"):
+        with pytest.raises(
+            TypeError, match="Component callable must return Template or Callable:"
+        ):
             _ = html(t"<{BadFunctionComp}>Hello</{BadFunctionComp}>")
 
     @pytest.mark.parametrize(
@@ -1829,7 +1831,9 @@ class TestComponentErrors:
 
             return component_object
 
-        with pytest.raises(TypeError, match="Unknown component return value:"):
+        with pytest.raises(
+            TypeError, match="Component object must return Template when called:"
+        ):
             _ = html(t"<{BadFactoryComp}>Hello</{BadFactoryComp}>")
 
 
@@ -1916,11 +1920,11 @@ class TestComponentProcessor:
             self,
             template: Template,
             last_ctx: ProcessContext,
-            component_callable: ComponentCallable,  # @NOTE: What should this be?
+            component_callable: object,
             attrs: tuple[TAttribute, ...],
             component_template: Template,
             provided_attrs: tuple[Attribute, ...] = (),
-        ) -> ComponentObject | Template:
+        ) -> tuple[Template, ComponentObject | None]:
             from inspect import isclass
 
             system_ctx = SystemCtx.get()

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -1,6 +1,7 @@
 import datetime
 import typing as t
 from collections.abc import Callable
+from contextvars import ContextVar
 from dataclasses import dataclass
 from itertools import chain, product
 from string.templatelib import Template
@@ -13,15 +14,21 @@ from .callables import get_callable_info
 from .escaping import escape_html_text
 from .processor import (
     CachedTemplateParserProxy,
+    ComponentCallable,
+    ComponentObject,
+    IComponentProcessor,
     ProcessContext,
     TemplateParserProxy,
     TemplateProcessor,
     _make_default_template_processor,
+    _resolve_t_attrs,
+    make_ctx,
 )
 from .processor import (
     _prep_component_kwargs as prep_component_kwargs,
 )
 from .protocols import HasHTMLDunder
+from .tnodes import TAttribute
 
 processor_api = _make_default_template_processor(
     parser_api=TemplateParserProxy(),  # do not use cache
@@ -1823,6 +1830,62 @@ class TestComponentErrors:
 
         with pytest.raises(TypeError, match="Unknown component return value:"):
             _ = html(t"<{BadFactoryComp}>Hello</{BadFactoryComp}>")
+
+
+@dataclass()
+class SystemState:
+    path_prefix: str
+
+
+SystemCtx: ContextVar[SystemState | None] = ContextVar("SystemCtx", default=None)
+
+
+class TestComponentProcessor:
+    class SystemComponentProcessor(IComponentProcessor):
+        def process(
+            self,
+            template: Template,
+            last_ctx: ProcessContext,
+            component_callable: ComponentCallable,
+            attrs: tuple[TAttribute, ...],
+            component_template: Template,
+        ) -> ComponentObject | Template:
+
+            system_ctx = SystemCtx.get()
+            if system_ctx is not None:
+                provided_attrs = (("system_path_prefix", system_ctx.path_prefix),)
+            else:
+                provided_attrs = ()
+            kwargs = prep_component_kwargs(
+                get_callable_info(component_callable),
+                _resolve_t_attrs(attrs, template.interpolations),
+                children=component_template,
+                provided_attrs=provided_attrs,
+            )
+            return component_callable(**kwargs)
+
+    def test_replacement(self):
+        def Header(children: Template) -> Template:
+            return t"<div class=hdr>{children}</div>"
+
+        def Nav(system_path_prefix: str = "") -> Template:
+            about_url = f"{system_path_prefix.rstrip('/')}/about"
+            return t"<div class=nav><a href={about_url}>About</a></div>"
+
+        sys_comp_processor = self.SystemComponentProcessor()
+
+        tp = TemplateProcessor(component_processor_api=sys_comp_processor)
+
+        assert tp.process(t"<{Header}><{Nav} /></{Header}>") == (
+            '<div class="hdr"><div class="nav"><a href="/about">About</a></div></div>'
+        )
+        with SystemCtx.set(SystemState(path_prefix="https://example.com/")):
+            assert tp.process(t"<{Header}><{Nav} /></{Header}>") == (
+                '<div class="hdr"><div class="nav"><a href="https://example.com/about">About</a></div></div>'
+            )
+            assert tp.process(t"<{Header}><{Nav} /></{Header}>") != (
+                '<div class="hdr"><div class="nav"><a href="/about">About</a></div></div>'
+            )
 
 
 def test_integration_basic():

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -2,7 +2,7 @@ import datetime
 import typing as t
 from collections.abc import Callable
 from contextvars import ContextVar
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from itertools import chain, product
 from string.templatelib import Template
 
@@ -13,15 +13,16 @@ from markupsafe import escape as markupsafe_escape
 from .callables import get_callable_info
 from .escaping import escape_html_text
 from .processor import (
+    Attribute,
     CachedTemplateParserProxy,
     ComponentCallable,
     ComponentObject,
+    ComponentProcessor,
     IComponentProcessor,
     ProcessContext,
     TemplateParserProxy,
     TemplateProcessor,
     _make_default_template_processor,
-    _resolve_t_attrs,
     make_ctx,
 )
 from .processor import (
@@ -1834,57 +1835,105 @@ class TestComponentErrors:
 
 @dataclass()
 class SystemState:
-    path_prefix: str
+    components: dict[object, ComponentCallable] = field(
+        default_factory=dict
+    )  # t.Type[t.Protocol]
 
 
 SystemCtx: ContextVar[SystemState | None] = ContextVar("SystemCtx", default=None)
 
 
 class TestComponentProcessor:
+    class IHeader(t.Protocol):
+        children: Template
+        hdr_class: str
+
+        def __call__(self) -> Template: ...
+
+    @dataclass
+    class Header(IHeader):
+        children: Template
+
+        hdr_class: str = "hdr"
+
+        def __call__(self) -> Template:
+            return t"<div class={self.hdr_class}>{self.children}</div>"
+
+    class INav(t.Protocol):
+        links: tuple[tuple[str, str], ...]
+
+        def __call__(self) -> Template: ...
+
+    @dataclass
+    class Nav(INav):
+        links: tuple[tuple[str, str], ...] = ()
+
+        nav_class: str = "nav"
+
+        def _make_nav_links(self) -> list[Template]:
+            return [t"<a href={href}>{label}</a>" for label, href in self.links]
+
+        def __call__(self) -> Template:
+            return t"<div class={self.nav_class}>{self._make_nav_links()}</div>"
+
+    @dataclass
+    class Logo:  # NO DI / NO Protocol
+        logo_fallback: str = "LOGO"
+
+        logo_class: str = "logo"
+
+        def __call__(self) -> Template:
+            return t"<span class={self.logo_class}>{self.logo_fallback}</span>"
+
+    @dataclass
     class SystemComponentProcessor(IComponentProcessor):
+        default_component_processor_api: IComponentProcessor = field(
+            default_factory=ComponentProcessor
+        )
+
         def process(
             self,
             template: Template,
             last_ctx: ProcessContext,
-            component_callable: ComponentCallable,
+            component_callable: ComponentCallable,  # @NOTE: What should this be?
             attrs: tuple[TAttribute, ...],
             component_template: Template,
+            provided_attrs: tuple[Attribute, ...] = (),
         ) -> ComponentObject | Template:
+            from inspect import isclass
 
             system_ctx = SystemCtx.get()
-            if system_ctx is not None:
-                provided_attrs = (("system_path_prefix", system_ctx.path_prefix),)
-            else:
-                provided_attrs = ()
-            kwargs = prep_component_kwargs(
-                get_callable_info(component_callable),
-                _resolve_t_attrs(attrs, template.interpolations),
-                children=component_template,
+            if (
+                system_ctx is not None
+                and isclass(component_callable)
+                and t.is_protocol(component_callable)
+                and component_callable in system_ctx.components
+            ):
+                component_callable = system_ctx.components[component_callable]
+            return self.default_component_processor_api.process(
+                template=template,
+                last_ctx=last_ctx,
+                component_callable=component_callable,
+                attrs=attrs,
+                component_template=component_template,
                 provided_attrs=provided_attrs,
             )
-            return component_callable(**kwargs)
 
     def test_replacement(self):
-        def Header(children: Template) -> Template:
-            return t"<div class=hdr>{children}</div>"
-
-        def Nav(system_path_prefix: str = "") -> Template:
-            about_url = f"{system_path_prefix.rstrip('/')}/about"
-            return t"<div class=nav><a href={about_url}>About</a></div>"
-
         sys_comp_processor = self.SystemComponentProcessor()
 
         tp = TemplateProcessor(component_processor_api=sys_comp_processor)
 
-        assert tp.process(t"<{Header}><{Nav} /></{Header}>") == (
-            '<div class="hdr"><div class="nav"><a href="/about">About</a></div></div>'
-        )
-        with SystemCtx.set(SystemState(path_prefix="https://example.com/")):
-            assert tp.process(t"<{Header}><{Nav} /></{Header}>") == (
-                '<div class="hdr"><div class="nav"><a href="https://example.com/about">About</a></div></div>'
-            )
-            assert tp.process(t"<{Header}><{Nav} /></{Header}>") != (
-                '<div class="hdr"><div class="nav"><a href="/about">About</a></div></div>'
+        # Mapping established beforehand.
+        components: dict[object, ComponentCallable] = {  # t.Type[t.Protocol]
+            self.IHeader: self.Header,
+            self.INav: self.Nav,
+        }
+        with SystemCtx.set(SystemState(components=components)):
+            links = [("Home", "/"), ("About", "/about")]
+            header_t = t"<{self.IHeader}><{self.Logo} /><{self.INav} links={links} /></{self.IHeader}>"
+            assert tp.process(header_t) == (
+                '<div class="hdr"><span class="logo">LOGO</span><div class="nav"><a href="/">Home</a><a href="/about">About</a></div></div>'
             )
 
 


### PR DESCRIPTION
- Add ComponentProcessor extension point with example test
- Drop middleware api, "component object capturing", for now.
- Alter `prep_component_kwargs`
    - take in additional args via `provided_attrs`
    - add conditional flags to raise on positional only arguments and/or missing arguments
- Factor out embedded template extraction to "clear up" component processing
