### PR TITLE
Middleware API Demo

### DIFF
--- a/tdom/cvar_utils.py
+++ b/tdom/cvar_utils.py
@@ -1,0 +1,29 @@
+from contextvars import ContextVar, Token
+
+
+class ContextVarSetter:
+    """
+    Context manager for working with many context vars (instead of only 1).
+
+    This is meant to be created, used immediately and then discarded.
+
+    This allows for dynamically specifying a tuple of var / value pairs that
+    another part of the program can use to wrap some called code without knowing
+    anything about either.
+    """
+
+    context_values: tuple[tuple[ContextVar, object], ...]  # Cvar / value pair.
+    tokens: tuple[Token, ...]
+
+    def __init__(self, context_values=()):
+        self.context_values = context_values
+        self.tokens = ()
+
+    def __enter__(self):
+        """Set every given context var to its paired value."""
+        self.tokens = tuple(var.set(val) for var, val in self.context_values)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Reset every given context var."""
+        for idx, var_value in enumerate(self.context_values):
+            var_value[0].reset(self.tokens[idx])

--- a/tdom/cvar_utils_test.py
+++ b/tdom/cvar_utils_test.py
@@ -1,0 +1,72 @@
+import string
+from contextvars import ContextVar
+
+from .cvar_utils import ContextVarSetter
+
+CtxStr = ContextVar[str]("CtxStr", default="default")
+CtxInt = ContextVar[int]("CtxInt", default=0)
+
+
+def _assert_ctx(ctx_str: str = "default", ctx_int: int = 0):
+    assert CtxStr.get() == ctx_str
+    assert CtxInt.get() == ctx_int
+
+
+def test_set():
+    _assert_ctx()
+    with ContextVarSetter(
+        context_values=(
+            (CtxStr, "new"),
+            (CtxInt, 1),
+        )
+    ):
+        _assert_ctx("new", 1)
+    _assert_ctx()
+
+
+def test_nest():
+    _assert_ctx()
+    with ContextVarSetter(
+        context_values=(
+            (CtxStr, "new"),
+            (CtxInt, 1),
+        )
+    ):
+        _assert_ctx("new", 1)
+        with ContextVarSetter(
+            context_values=(
+                (CtxStr, "again"),
+                (CtxInt, 2),
+            )
+        ):
+            _assert_ctx("again", 2)
+        _assert_ctx("new", 1)
+    _assert_ctx()
+
+
+def test_reps():
+    _assert_ctx()
+    for index, leter in enumerate(string.ascii_lowercase):
+        with ContextVarSetter(
+            context_values=(
+                (CtxStr, leter),
+                (CtxInt, index),
+            )
+        ):
+            _assert_ctx(leter, index)
+        _assert_ctx()
+
+
+def test_empty():
+    _assert_ctx()
+    with ContextVarSetter(context_values=()):
+        # DO NOTHING BUT NOT AN ERROR
+        _assert_ctx()
+    _assert_ctx()
+
+
+def test_one():
+    _assert_ctx()
+    with ContextVarSetter(context_values=((CtxStr, "new"),)):
+        _assert_ctx("new")
+    _assert_ctx()

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -519,6 +519,7 @@ class IComponentProcessor(t.Protocol):
         component_callable: ComponentCallable,
         attrs: tuple[TAttribute, ...],
         component_template: Template,
+        provided_attrs: tuple[Attribute, ...] = (),
     ) -> ComponentObject | Template:
         """
         Process available component details into a queryable object or template.
@@ -539,6 +540,7 @@ class ComponentProcessor(IComponentProcessor):
         component_callable: ComponentCallable,
         attrs: tuple[TAttribute, ...],
         component_template: Template,
+        provided_attrs: tuple[Attribute, ...] = (),
     ) -> ComponentObject | Template:
         """
         Process available component details into a queryable object or template.
@@ -554,6 +556,7 @@ class ComponentProcessor(IComponentProcessor):
             get_callable_info(component_callable),
             _resolve_t_attrs(attrs, template.interpolations),
             children=component_template,
+            provided_attrs=provided_attrs,
         )
         return component_callable(**kwargs)
 

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -386,13 +386,24 @@ def _prep_component_kwargs(
     callable_info: CallableInfo,
     attrs: AttributesDict,
     children: Template,
+    provided_attrs: tuple[Attribute, ...] = (),
 ) -> AttributesDict:
+    """
+    Matchup kwargs from multiple sources to target the given callable.
+
+    The `provided_attrs` can be used by extensions that want to provide
+    kwargs even if they are not specified in a template.
+    """
     if callable_info.requires_positional:
         raise TypeError(
             "Component callables cannot have required positional arguments."
         )
 
     kwargs: AttributesDict = {}
+
+    for pattr_name, pattr_value in provided_attrs:
+        if pattr_name in callable_info.named_params or callable_info.kwargs:
+            kwargs[pattr_name] = pattr_value
 
     # Add all supported attributes
     for attr_name, attr_value in attrs.items():

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -387,6 +387,8 @@ def _prep_component_kwargs(
     attrs: AttributesDict,
     children: Template,
     provided_attrs: tuple[Attribute, ...] = (),
+    raise_on_requires_positional=True,
+    raise_on_missing=True,
 ) -> AttributesDict:
     """
     Matchup kwargs from multiple sources to target the given callable.
@@ -394,16 +396,14 @@ def _prep_component_kwargs(
     The `provided_attrs` can be used by extensions that want to provide
     kwargs even if they are not specified in a template.
     """
-    if callable_info.requires_positional:
+
+    # We can't know what kwarg to put here...
+    if raise_on_requires_positional and callable_info.requires_positional:
         raise TypeError(
             "Component callables cannot have required positional arguments."
         )
 
     kwargs: AttributesDict = {}
-
-    for pattr_name, pattr_value in provided_attrs:
-        if pattr_name in callable_info.named_params or callable_info.kwargs:
-            kwargs[pattr_name] = pattr_value
 
     # Add all supported attributes
     for attr_name, attr_value in attrs.items():
@@ -414,12 +414,20 @@ def _prep_component_kwargs(
     if "children" in callable_info.named_params or callable_info.kwargs:
         kwargs["children"] = children
 
+    # Add in provided attrs if they haven't been set already and are wanted.
+    for pattr_name, pattr_value in provided_attrs:
+        if pattr_name not in kwargs and (
+            pattr_name in callable_info.named_params or callable_info.kwargs
+        ):
+            kwargs[pattr_name] = pattr_value
+
     # Check to make sure we've fully satisfied the callable's requirements
-    missing = callable_info.required_named_params - kwargs.keys()
-    if missing:
-        raise TypeError(
-            f"Missing required parameters for component: {', '.join(missing)}"
-        )
+    if raise_on_missing:
+        missing = callable_info.required_named_params - kwargs.keys()
+        if missing:
+            raise TypeError(
+                f"Missing required parameters for component: {', '.join(missing)}"
+            )
 
     return kwargs
 
@@ -555,6 +563,8 @@ class ComponentProcessor(IComponentProcessor):
             _resolve_t_attrs(attrs, template.interpolations),
             children=component_template,
             provided_attrs=provided_attrs,
+            raise_on_requires_positional=True,
+            raise_on_missing=True,
         )
         res1 = component_callable(**kwargs)  # ty: ignore[call-top-callable]
         # This integration API seems a lot cleaner but we lose the ability for

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -574,7 +574,7 @@ class ComponentProcessor(IComponentProcessor):
         if isinstance(res1, Template):
             return res1, None
         elif callable(res1):
-            res2 = res1() # ty: ignore[call-top-callable]
+            res2 = res1()  # ty: ignore[call-top-callable]
             if isinstance(res2, Template):
                 # @TODO: It seems like we should not need this.
                 # Although our check against res2 doesn't seem to affect the

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -513,14 +513,13 @@ class IComponentProcessor(t.Protocol):
 
     def process(
         self,
-        # TODO: ? processor_api: IProcessor,
         template: Template,
         last_ctx: ProcessContext,
-        component_callable: ComponentCallable,
+        component_callable: t.Annotated[object, ComponentCallable],
         attrs: tuple[TAttribute, ...],
         component_template: Template,
         provided_attrs: tuple[Attribute, ...] = (),
-    ) -> ComponentObject | Template:
+    ) -> tuple[Template, ComponentObject | None]:
         """
         Process available component details into a queryable object or template.
         """
@@ -534,14 +533,13 @@ class ComponentProcessor(IComponentProcessor):
 
     def process(
         self,
-        # @TODO: ? processor_api: IProcessor,
         template: Template,
         last_ctx: ProcessContext,
-        component_callable: ComponentCallable,
+        component_callable: t.Annotated[object, ComponentCallable],
         attrs: tuple[TAttribute, ...],
         component_template: Template,
         provided_attrs: tuple[Attribute, ...] = (),
-    ) -> ComponentObject | Template:
+    ) -> tuple[Template, ComponentObject | None]:
         """
         Process available component details into a queryable object or template.
 
@@ -558,7 +556,28 @@ class ComponentProcessor(IComponentProcessor):
             children=component_template,
             provided_attrs=provided_attrs,
         )
-        return component_callable(**kwargs)
+        res1 = component_callable(**kwargs)  # ty: ignore[call-top-callable]
+        # This integration API seems a lot cleaner but we lose the ability for
+        # component_object.__call__ to be wrapped in any sort of context setting
+        # mechanism provided by the class, but maybe that's ok?  It could be
+        # cached on the instance although that is kind of gross.
+        if isinstance(res1, Template):
+            return res1, None
+        elif callable(res1):
+            res2 = res1() # ty: ignore[call-top-callable]
+            if isinstance(res2, Template):
+                # @TODO: It seems like we should not need this.
+                # Although our check against res2 doesn't seem to affect the
+                # return value of res1.
+                return res2, t.cast(ComponentObject, res1)
+            else:
+                raise TypeError(
+                    f"Component object must return Template when called: {type(res2)}"
+                )
+        else:
+            raise TypeError(
+                f"Component callable must return Template or Callable: {type(res1)}"
+            )
 
 
 class ITemplateProcessor(t.Protocol):
@@ -736,6 +755,33 @@ class TemplateProcessor(ITemplateProcessor):
             return attrs_str
         return ""
 
+    def _extract_component_template(
+        self,
+        template: Template,
+        attrs: tuple[TAttribute, ...],
+        start_i_index: int,
+        end_i_index: int | None,
+        check_callables: bool = True,
+    ) -> Template:
+        body_start_s_index = (
+            start_i_index
+            + 1
+            + len([1 for attr in attrs if not isinstance(attr, TLiteralAttribute)])
+        )
+        if start_i_index != end_i_index and end_i_index is not None:
+            # @TODO: We should do this during parsing.
+            if (
+                check_callables
+                and template.interpolations[start_i_index].value
+                != template.interpolations[end_i_index].value
+            ):
+                raise TypeError(
+                    "Component callable in start tag must match component callable in end tag."
+                )
+            return extract_embedded_template(template, body_start_s_index, end_i_index)
+        else:
+            return t""
+
     def _process_component(
         self,
         template: Template,
@@ -747,43 +793,15 @@ class TemplateProcessor(ITemplateProcessor):
         """
         Invoke a component and process the result into a string.
         """
-        body_start_s_index = (
-            start_i_index
-            + 1
-            + len([1 for attr in attrs if not isinstance(attr, TLiteralAttribute)])
+        children_template = self._extract_component_template(
+            template, attrs, start_i_index, end_i_index, check_callables=True
         )
-        start_i = template.interpolations[start_i_index]
-        component_callable = t.cast(ComponentCallable, start_i.value)
-        if start_i_index != end_i_index and end_i_index is not None:
-            # @TODO: We should do this during parsing.
-            children_template = extract_embedded_template(
-                template, body_start_s_index, end_i_index
-            )
-            if component_callable != template.interpolations[end_i_index].value:
-                raise TypeError(
-                    "Component callable in start tag must match component callable in end tag."
-                )
-        else:
-            children_template = t""
-
-        result_t = self.component_processor_api.process(
+        component_callable = template.interpolations[start_i_index].value
+        result_t, component_object = self.component_processor_api.process(
             template, last_ctx, component_callable, attrs, children_template
         )
-
-        if (
-            result_t is not None
-            and not isinstance(result_t, Template)
-            and callable(result_t)
-        ):
-            component_obj = t.cast(ComponentObject, result_t)  # ty: ignore[redundant-cast]
-            result_t = component_obj()
-        else:
-            component_obj = None
-
-        if isinstance(result_t, Template):
-            return self._process_template(result_t, last_ctx)
-        else:
-            raise TypeError(f"Unknown component return value: {type(result_t)}")
+        assert isinstance(component_object, object)
+        return self._process_template(result_t, last_ctx)
 
     def _process_raw_texts(
         self,

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -546,6 +546,10 @@ class ComponentProcessor(IComponentProcessor):
         Default strategy just uses `_prep_component_kwargs` for `kwargs`
         injecting `children` if asked.
         """
+        if not callable(component_callable):
+            raise TypeError(
+                f"Component callable must be callable: {type(component_callable)}"
+            )
         kwargs = _prep_component_kwargs(
             get_callable_info(component_callable),
             _resolve_t_attrs(attrs, template.interpolations),

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -527,9 +527,9 @@ class IComponentProcessor(t.Protocol):
         attrs: tuple[TAttribute, ...],
         component_template: Template,
         provided_attrs: tuple[Attribute, ...] = (),
-    ) -> tuple[Template, ComponentObject | None]:
+    ) -> Template:
         """
-        Process available component details into a queryable object or template.
+        Process available component details into a Template.
         """
         ...
 
@@ -547,12 +547,29 @@ class ComponentProcessor(IComponentProcessor):
         attrs: tuple[TAttribute, ...],
         component_template: Template,
         provided_attrs: tuple[Attribute, ...] = (),
-    ) -> tuple[Template, ComponentObject | None]:
+    ) -> Template:
         """
-        Process available component details into a queryable object or template.
+        Process available component details into a Template.
 
-        Default strategy just uses `_prep_component_kwargs` for `kwargs`
-        injecting `children` if asked.
+        There are two general "styles" supported:
+
+        1. FunctionComponent
+
+        Calling `component_callable` with the prepared kwargs should
+        return a `Template`.
+
+        The primary purpose of this style is to support
+        using a normal function as a component.
+
+        2. FactoryComponent
+
+        Calling `component_callable` with the prepared kwargs should
+        return another `Callable` which when called with no arguments should
+        return a `Template`.
+
+        The primary purpose of this style is to support
+        using a `dataclass` with `def __call__(self) -> Template` as a
+        component.
         """
         if not callable(component_callable):
             raise TypeError(
@@ -567,19 +584,12 @@ class ComponentProcessor(IComponentProcessor):
             raise_on_missing=True,
         )
         res1 = component_callable(**kwargs)  # ty: ignore[call-top-callable]
-        # This integration API seems a lot cleaner but we lose the ability for
-        # component_object.__call__ to be wrapped in any sort of context setting
-        # mechanism provided by the class, but maybe that's ok?  It could be
-        # cached on the instance although that is kind of gross.
         if isinstance(res1, Template):
-            return res1, None
+            return res1
         elif callable(res1):
             res2 = res1()  # ty: ignore[call-top-callable]
             if isinstance(res2, Template):
-                # @TODO: It seems like we should not need this.
-                # Although our check against res2 doesn't seem to affect the
-                # return value of res1.
-                return res2, t.cast(ComponentObject, res1)
+                return res2
             else:
                 raise TypeError(
                     f"Component object must return Template when called: {type(res2)}"
@@ -807,10 +817,9 @@ class TemplateProcessor(ITemplateProcessor):
             template, attrs, start_i_index, end_i_index, check_callables=True
         )
         component_callable = template.interpolations[start_i_index].value
-        result_t, component_object = self.component_processor_api.process(
+        result_t = self.component_processor_api.process(
             template, last_ctx, component_callable, attrs, children_template
         )
-        assert isinstance(component_object, object)
         return self._process_template(result_t, last_ctx)
 
     def _process_raw_texts(

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -497,6 +497,52 @@ class CachedTemplateParserProxy(TemplateParserProxy):
         return self._to_tnode(CachableTemplate(template))
 
 
+class IComponentProcessor(t.Protocol):
+    """Isolate component processing to allow for replacement."""
+
+    def process(
+        self,
+        # TODO: ? processor_api: IProcessor,
+        template: Template,
+        last_ctx: ProcessContext,
+        component_callable: ComponentCallable,
+        attrs: tuple[TAttribute, ...],
+        component_template: Template,
+    ) -> ComponentObject | Template:
+        """
+        Process available component details into a queryable object or template.
+        """
+        ...
+
+
+class ComponentProcessor(IComponentProcessor):
+    """
+    Default component processor.
+    """
+
+    def process(
+        self,
+        # @TODO: ? processor_api: IProcessor,
+        template: Template,
+        last_ctx: ProcessContext,
+        component_callable: ComponentCallable,
+        attrs: tuple[TAttribute, ...],
+        component_template: Template,
+    ) -> ComponentObject | Template:
+        """
+        Process available component details into a queryable object or template.
+
+        Default strategy just uses `_prep_component_kwargs` for `kwargs`
+        injecting `children` if asked.
+        """
+        kwargs = _prep_component_kwargs(
+            get_callable_info(component_callable),
+            _resolve_t_attrs(attrs, template.interpolations),
+            children=component_template,
+        )
+        return component_callable(**kwargs)
+
+
 class ITemplateProcessor(t.Protocol):
     def process(self, root_template: Template, assume_ctx: ProcessContext) -> str: ...
 
@@ -504,6 +550,10 @@ class ITemplateProcessor(t.Protocol):
 @dataclass(frozen=True)
 class TemplateProcessor(ITemplateProcessor):
     parser_api: ITemplateParserProxy = field(default_factory=CachedTemplateParserProxy)
+
+    component_processor_api: IComponentProcessor = field(
+        default_factory=ComponentProcessor
+    )
 
     escape_html_text: Callable = default_escape_html_text
 
@@ -698,16 +748,10 @@ class TemplateProcessor(ITemplateProcessor):
         else:
             children_template = t""
 
-        if not callable(component_callable):
-            raise TypeError("Component callable must be callable.")
-
-        kwargs = _prep_component_kwargs(
-            get_callable_info(component_callable),
-            _resolve_t_attrs(attrs, template.interpolations),
-            children=children_template,
+        result_t = self.component_processor_api.process(
+            template, last_ctx, component_callable, attrs, children_template
         )
 
-        result_t = component_callable(**kwargs)
         if (
             result_t is not None
             and not isinstance(result_t, Template)

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -484,10 +484,35 @@ class ProcessContext:
         )
 
 
-type FunctionComponent = Callable[..., Template]
-type FactoryComponent = Callable[..., ComponentObject]
-type ComponentCallable = FunctionComponent | FactoryComponent
-type ComponentObject = Callable[[], Template]
+@t.runtime_checkable
+class IFunctionComponent(t.Protocol):
+    __call__: Callable[..., Template]
+
+
+@t.runtime_checkable
+class IFunctionMiddlewareComponent(t.Protocol):
+    __call__: Callable[..., tuple[Template, object]]
+
+
+@t.runtime_checkable
+class IFactoryComponent(t.Protocol):
+    __call__: IFunctionComponent
+
+
+@t.runtime_checkable
+class IFactoryMiddlewareComponent(t.Protocol):
+    __call__: IFunctionMiddlewareComponent
+
+
+# type FunctionComponent = Callable[..., Template | tuple[Template, object]]
+# type FactoryComponent = Callable[..., ComponentObject]
+type ComponentCallable = (
+    IFunctionComponent
+    | IFactoryComponent
+    | IFunctionMiddlewareComponent
+    | IFactoryMiddlewareComponent
+)
+type ComponentObject = IFunctionComponent | IFunctionMiddlewareComponent
 
 
 type NormalTextInterpolationValue = (
@@ -563,7 +588,7 @@ class ComponentProcessor(IComponentProcessor):
         self,
         template: Template,
         last_ctx: ProcessContext,
-        component_callable: t.Annotated[object, ComponentCallable],
+        component_callable: t.Annotated[object, IFactoryComponent | IFunctionComponent],
         attrs: tuple[TAttribute, ...],
         component_template: Template,
         provided_attrs: tuple[Attribute, ...] = (),
@@ -605,34 +630,40 @@ class ComponentProcessor(IComponentProcessor):
         )
         res1 = component_callable(**kwargs)  # ty: ignore[call-top-callable]
         if isinstance(res1, Template):
-            return res1, None
+            return res1
+        elif isinstance(res1, tuple):
+            return self._check_tuple_response(res1, error_target="callable")
         elif callable(res1):
             res2 = res1()  # ty: ignore[call-top-callable]
             if isinstance(res2, Template):
                 return res2
             elif isinstance(res2, tuple):
-                if len(res2) == 2:
-                    if not isinstance(res2[0], Template):
-                        raise TypeError(
-                            f"Component object returned unxpected type in first entry of 2-tuple: {type(res2[0])}"
-                        )
-                    else:
-                        # @TYPING:
-                        # Rebuild tuple so TY can correctly narrow types,
-                        # pyright works with `return res2`.
-                        return (res2[0], res2[1])
-                else:
-                    raise ValueError(
-                        f"Component object returned tuple with length != 2: {len(res2)}"
-                    )
-
+                return self._check_tuple_response(res2, error_target="object")
             else:
                 raise TypeError(
                     f"Component object must return Template or 2-tuple when called: {type(res2)}"
                 )
         else:
             raise TypeError(
-                f"Component callable must return Template or Callable: {type(res1)}"
+                f"Component callable must return Template, 2-tuple or Callable: {type(res1)}"
+            )
+
+    def _check_tuple_response(
+        self, response: tuple, error_target: str
+    ) -> tuple[Template, object]:
+        if len(response) == 2:
+            if not isinstance(response[0], Template):
+                raise TypeError(
+                    f"Component {error_target} returned unxpected type in first entry of 2-tuple: {type(response[0])}"
+                )
+            else:
+                # @TYPING:
+                # Rebuild tuple so TY can correctly narrow types,
+                # pyright works with `return response`.
+                return (response[0], response[1])
+        else:
+            raise TypeError(
+                f"Component {error_target} returned tuple with length != 2: {len(response)}"
             )
 
 

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -393,8 +393,26 @@ def _prep_component_kwargs(
     """
     Matchup kwargs from multiple sources to target the given callable.
 
-    The `provided_attrs` can be used by extensions that want to provide
-    kwargs even if they are not specified in a template.
+    `provided_attrs`:
+        These can be used by extensions that want to provide
+        attrs even if they are not specified in the component's `attrs` in
+        the template. If an attribute with the same name is provided in
+        `attrs` then it takes priority over entries in `provided_attrs`.
+        @NOTE: These will be injected into any component with `**kwargs`
+        in their signature unless provided already by `attrs`.
+
+    `raise_on_requires_positional`:
+        Optionally check and raise `TypeError` if the `callable_info` requires
+        positional arguments which we cannot fulfill normally.
+        An exception might not be desired if the caller will finish preparing
+        the arguments after this call.
+
+    `raise_on_missing`:
+        Optionally check and raise `TypeError` if we are not able to fulfill all
+        the arguments the `callable_info` expects since in the common case this
+        raise an exception whose cause might not be clear.
+        An exception might not be desired if the caller will finish preparing
+        the arguments after this call.
     """
 
     # We can't know what kwarg to put here...

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -1,5 +1,6 @@
 import typing as t
 from collections.abc import Callable, Iterable, Sequence
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from functools import lru_cache
 from string.templatelib import Interpolation, Template
@@ -7,6 +8,7 @@ from string.templatelib import Interpolation, Template
 from markupsafe import Markup
 
 from .callables import CallableInfo, get_callable_info
+from .cvar_utils import ContextVarSetter
 from .escaping import (
     escape_html_comment as default_escape_html_comment,
 )
@@ -545,7 +547,7 @@ class IComponentProcessor(t.Protocol):
         attrs: tuple[TAttribute, ...],
         component_template: Template,
         provided_attrs: tuple[Attribute, ...] = (),
-    ) -> Template:
+    ) -> Template | tuple[Template, object]:
         """
         Process available component details into a Template.
         """
@@ -565,7 +567,7 @@ class ComponentProcessor(IComponentProcessor):
         attrs: tuple[TAttribute, ...],
         component_template: Template,
         provided_attrs: tuple[Attribute, ...] = (),
-    ) -> Template:
+    ) -> Template | tuple[Template, object]:
         """
         Process available component details into a Template.
 
@@ -603,19 +605,46 @@ class ComponentProcessor(IComponentProcessor):
         )
         res1 = component_callable(**kwargs)  # ty: ignore[call-top-callable]
         if isinstance(res1, Template):
-            return res1
+            return res1, None
         elif callable(res1):
             res2 = res1()  # ty: ignore[call-top-callable]
             if isinstance(res2, Template):
                 return res2
+            elif isinstance(res2, tuple):
+                if len(res2) == 2:
+                    if not isinstance(res2[0], Template):
+                        raise TypeError(
+                            f"Component object returned unxpected type in first entry of 2-tuple: {type(res2[0])}"
+                        )
+                    else:
+                        # @TYPING:
+                        # Rebuild tuple so TY can correctly narrow types,
+                        # pyright works with `return res2`.
+                        return (res2[0], res2[1])
+                else:
+                    raise ValueError(
+                        f"Component object returned tuple with length != 2: {len(res2)}"
+                    )
+
             else:
                 raise TypeError(
-                    f"Component object must return Template when called: {type(res2)}"
+                    f"Component object must return Template or 2-tuple when called: {type(res2)}"
                 )
         else:
             raise TypeError(
                 f"Component callable must return Template or Callable: {type(res1)}"
             )
+
+
+@t.runtime_checkable
+class IMiddlewareGetContextValues(t.Protocol):
+    """
+    Middleware that provides a tuple of 2-tuples each with a context variable
+    paired with a value to set when processing the component's template.
+    """
+
+    # @TODO: Can we match a contextvar's type with the value to set like this?
+    def get_context_values(self) -> tuple[tuple[ContextVar, object], ...]: ...
 
 
 class ITemplateProcessor(t.Protocol):
@@ -835,10 +864,44 @@ class TemplateProcessor(ITemplateProcessor):
             template, attrs, start_i_index, end_i_index, check_callables=True
         )
         component_callable = template.interpolations[start_i_index].value
-        result_t = self.component_processor_api.process(
+        result = self.component_processor_api.process(
             template, last_ctx, component_callable, attrs, children_template
         )
-        return self._process_template(result_t, last_ctx)
+        if isinstance(result, Template):
+            result_t, middleware_api = result, None
+        elif isinstance(result, tuple):
+            if len(result) == 2:
+                if not isinstance(result[0], Template):
+                    raise TypeError(
+                        f"Component processor returned unxpected type in first entry of 2-tuple: {type(result[0])}"
+                    )
+                else:
+                    result_t, middleware_api = result
+            else:
+                raise ValueError(
+                    f"Component processor returned tuple with length != 2: {len(result)}"
+                )
+        else:
+            raise TypeError(
+                f"Component processor should return unexpected type: {type(result)}"
+            )
+
+        context_values: tuple[tuple[ContextVar, object], ...] = ()
+
+        if middleware_api is not None:
+            if isinstance(middleware_api, IMiddlewareGetContextValues):
+                context_values = middleware_api.get_context_values()
+            else:
+                # @DESIGN: It is NOT an error if a middleware object is provided but it
+                # provides no actual middleware functionality.  Should it be?
+                pass
+
+        # Try to consolidate "final" call(s) to the last block regardless of middleware.
+        if context_values:
+            with ContextVarSetter(context_values=context_values):
+                return self._process_template(result_t, last_ctx)
+        else:
+            return self._process_template(result_t, last_ctx)
 
     def _process_raw_texts(
         self,

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -895,44 +895,64 @@ class TemplateProcessor(ITemplateProcessor):
             template, attrs, start_i_index, end_i_index, check_callables=True
         )
         component_callable = template.interpolations[start_i_index].value
-        result = self.component_processor_api.process(
+        response = self.component_processor_api.process(
             template, last_ctx, component_callable, attrs, children_template
         )
-        if isinstance(result, Template):
-            result_t, middleware_api = result, None
-        elif isinstance(result, tuple):
-            if len(result) == 2:
-                if not isinstance(result[0], Template):
+        if isinstance(response, Template):
+            response_t = response
+            response_middleware = None
+        elif isinstance(response, tuple):
+            if len(response) == 2:
+                if not isinstance(response[0], Template):
                     raise TypeError(
-                        f"Component processor returned unxpected type in first entry of 2-tuple: {type(result[0])}"
+                        f"Component processor returned unxpected type in first entry of 2-tuple: {type(response[0])}"
                     )
                 else:
-                    result_t, middleware_api = result
+                    response_t, response_middleware = response
             else:
                 raise ValueError(
-                    f"Component processor returned tuple with length != 2: {len(result)}"
+                    f"Component processor returned tuple with length != 2: {len(response)}"
                 )
         else:
             raise TypeError(
-                f"Component processor should return unexpected type: {type(result)}"
+                f"Component processor should return unexpected type: {type(response)}"
             )
+
+        if response_middleware is not None:
+            return self._process_middleware(
+                template, last_ctx, response_t, response_middleware
+            )
+        else:
+            return self._process_template(response_t, last_ctx)
+
+    def _process_middleware(
+        self,
+        template: Template,
+        last_ctx: ProcessContext,
+        response_t: Template,
+        response_middleware: object,
+    ) -> str:
+        """
+        Process the given middleware and apply it to the component's response
+        template.
+        """
 
         context_values: tuple[tuple[ContextVar, object], ...] = ()
 
-        if middleware_api is not None:
-            if isinstance(middleware_api, IMiddlewareGetContextValues):
-                context_values = middleware_api.get_context_values()
-            else:
-                # @DESIGN: It is NOT an error if a middleware object is provided but it
-                # provides no actual middleware functionality.  Should it be?
-                pass
+        if isinstance(
+            response_middleware, IMiddlewareGetContextValues
+        ):  # @TODO: Probably use hasattr.
+            context_values = response_middleware.get_context_values()
+        else:
+            # @DESIGN: It is NOT an error if a middleware object is provided but it
+            # provides no actual middleware functionality.  Should it be?
+            pass
 
-        # Try to consolidate "final" call(s) to the last block regardless of middleware.
         if context_values:
             with ContextVarSetter(context_values=context_values):
-                return self._process_template(result_t, last_ctx)
+                return self._process_template(response_t, last_ctx)
         else:
-            return self._process_template(result_t, last_ctx)
+            return self._process_template(response_t, last_ctx)
 
     def _process_raw_texts(
         self,

--- a/tdom/processor_extension_test.py
+++ b/tdom/processor_extension_test.py
@@ -6,7 +6,6 @@ from string.templatelib import Template
 from .processor import (
     Attribute,
     ComponentCallable,
-    ComponentObject,
     ComponentProcessor,
     IComponentProcessor,
     ProcessContext,
@@ -102,7 +101,7 @@ class TestComponentProcessor:
             attrs: tuple[TAttribute, ...],
             component_template: Template,
             provided_attrs: tuple[Attribute, ...] = (),
-        ) -> tuple[Template, ComponentObject | None]:
+        ) -> Template:
             from inspect import isclass
 
             system_ctx = SystemCtx.get()
@@ -112,28 +111,12 @@ class TestComponentProcessor:
                 and t.is_protocol(component_callable)
                 and component_callable in system_ctx.components
             ):
-                # Use the protocol to get the concrete component factory.
-                # @NOTE: This is using the contextvars.ContextVar to
-                # get this information but maybe in the future we'd have
-                # a way to get ctx directly from a parameter.
                 component_callable = system_ctx.components[component_callable]
 
-            # Also pass in system provided attributes to EVERY
-            # component (but it will only be used during the call if it needed.
-            # @NOTE: This is using the contextvars.ContextVar to
-            # get this information but maybe in the future we'd have
-            # a way to get ctx directly from a parameter.
             if system_ctx is not None:
                 system_attrs = (("request", system_ctx.request),)
                 provided_attrs = provided_attrs + system_attrs
 
-            # @NOTE: We mostly just put the correct values in the right places
-            # to perform the default component processing.
-            # - `component_callable` is now the actual concrete implementation
-            # - `provided_attrs` now has attrs that might not be in the template
-            # So we can just wrap the default processor and let it do all the
-            # work. BUT... if we wanted to just replace the invocation we could
-            # do that and just return the correct thing ourselves.
             return self.default_component_processor_api.process(
                 template=template,
                 last_ctx=last_ctx,

--- a/tdom/processor_extension_test.py
+++ b/tdom/processor_extension_test.py
@@ -1,11 +1,9 @@
-import typing as t
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from string.templatelib import Template
 
 from .processor import (
     Attribute,
-    ComponentCallable,
     ComponentProcessor,
     IComponentProcessor,
     ProcessContext,
@@ -14,81 +12,36 @@ from .processor import (
 from .tnodes import TAttribute
 
 
-class ISimpleRequest(t.Protocol):
-    def make_url(self, path: str) -> str: ...
+@dataclass(frozen=True, slots=True)
+class AppState:
+    theme_class: str
 
 
-@dataclass()
-class SystemState:
-    request: ISimpleRequest
-    components: dict[object, ComponentCallable] = field(
-        default_factory=dict
-    )  # t.Type[t.Protocol]
-
-
-SystemCtx: ContextVar[SystemState | None] = ContextVar("SystemCtx", default=None)
+AppStateCtx: ContextVar[AppState | None] = ContextVar("AppStateCtx", default=None)
 
 
 class TestComponentProcessor:
     @dataclass
-    class SimpleRequest(ISimpleRequest):
-        scheme: str
-        host: str
-
-        def make_url(self, path: str) -> str:
-            # @NOTE: Don't actually make URLs this way, this is just an example.
-            return f"{self.scheme}://{self.host}/{path.lstrip('/')}"
-
-    class IHeader(t.Protocol):
+    class Body:
         children: Template
-        hdr_class: str
 
-        def __call__(self) -> Template: ...
+        def __call__(self) -> Template:
+            return t"<body>{self.children}</body>"
 
     @dataclass
-    class Header(IHeader):
+    class Header:
         children: Template
+
+        app_state: AppState
 
         hdr_class: str = "hdr"
 
         def __call__(self) -> Template:
-            return t"<div class={self.hdr_class}>{self.children}</div>"
-
-    class INav(t.Protocol):
-        request: ISimpleRequest
-
-        links: tuple[tuple[str, str], ...]
-
-        def __call__(self) -> Template: ...
+            return t"<div class={self.hdr_class} class={self.app_state.theme_class}>{self.children}</div>"
 
     @dataclass
-    class Nav(INav):
-        request: ISimpleRequest
-
-        links: tuple[tuple[str, str], ...] = ()
-
-        nav_class: str = "nav"
-
-        def _make_nav_links(self) -> list[Template]:
-            return [
-                t"<a href={self.request.make_url(href)}>{label}</a>"
-                for label, href in self.links
-            ]
-
-        def __call__(self) -> Template:
-            return t"<div class={self.nav_class}>{self._make_nav_links()}</div>"
-
-    @dataclass
-    class Logo:  # NO DI / NO Protocol
-        logo_fallback: str = "LOGO"
-
-        logo_class: str = "logo"
-
-        def __call__(self) -> Template:
-            return t"<span class={self.logo_class}>{self.logo_fallback}</span>"
-
-    @dataclass
-    class SystemComponentProcessor(IComponentProcessor):
+    class AppStateComponentProcessor(IComponentProcessor):
+        # Delegate to the default processor to reuse code.
         default_component_processor_api: IComponentProcessor = field(
             default_factory=ComponentProcessor
         )
@@ -102,50 +55,49 @@ class TestComponentProcessor:
             component_template: Template,
             provided_attrs: tuple[Attribute, ...] = (),
         ) -> Template:
-            from inspect import isclass
-
-            system_ctx = SystemCtx.get()
-            if (
-                system_ctx is not None
-                and isclass(component_callable)
-                and t.is_protocol(component_callable)
-                and component_callable in system_ctx.components
-            ):
-                component_callable = system_ctx.components[component_callable]
-
-            if system_ctx is not None:
-                system_attrs = (("request", system_ctx.request),)
-                provided_attrs = provided_attrs + system_attrs
-
+            # For now we just make the app state available to EVERY component
+            # a smarter strategy would be to only include it if asked via
+            # the callable's signature or even the callable's typehints.
+            # But for a test this is OK.
+            app_state = AppStateCtx.get()
+            extended_attrs = provided_attrs + (("app_state", app_state),)
             return self.default_component_processor_api.process(
                 template=template,
                 last_ctx=last_ctx,
                 component_callable=component_callable,
                 attrs=attrs,
                 component_template=component_template,
-                provided_attrs=provided_attrs,
+                provided_attrs=extended_attrs,
             )
 
-    def test_replacement(self):
-        sys_comp_processor = self.SystemComponentProcessor()
+    def _make_html(self):
+        app_state_processor = self.AppStateComponentProcessor()
+        tp = TemplateProcessor(component_processor_api=app_state_processor)
+        assume_ctx = ProcessContext()
 
-        tp = TemplateProcessor(component_processor_api=sys_comp_processor)
+        def _html(template: Template, app_state: AppState | None = None) -> str:
+            if app_state is None:
+                app_state = AppState(theme_class="theme-default")
+            with AppStateCtx.set(app_state):
+                return tp.process(template, assume_ctx=assume_ctx)
 
-        # Mapping established beforehand.
-        components: dict[object, ComponentCallable] = {  # t.Type[t.Protocol]
-            self.IHeader: self.Header,
-            self.INav: self.Nav,
-        }
-        current_request = self.SimpleRequest(scheme="https", host="www.example.com")
-        with SystemCtx.set(SystemState(components=components, request=current_request)):
-            links = [("Home", "/"), ("About", "/about")]
-            header_t = t"<{self.IHeader}><{self.Logo} /><{self.INav} links={links} /></{self.IHeader}>"
-            assert tp.process(header_t, assume_ctx=ProcessContext()) == (
-                '<div class="hdr">'
-                '<span class="logo">LOGO</span>'
-                '<div class="nav">'
-                '<a href="https://www.example.com/">Home</a>'
-                '<a href="https://www.example.com/about">About</a>'
-                "</div>"
-                "</div>"
-            )
+        return _html
+
+    def test_injected_app_state(self):
+        name = "App"
+        body_t = (
+            t"<{self.Body}><{self.Header}><h1>{name}</h1></{self.Header}></{self.Body}>"
+        )
+        html = self._make_html()
+        assert (
+            html(body_t, app_state=None)
+            == '<body><div class="hdr theme-default"><h1>App</h1></div></body>'
+        )
+        assert (
+            html(body_t, app_state=AppState(theme_class="theme-spring"))
+            == '<body><div class="hdr theme-spring"><h1>App</h1></div></body>'
+        )
+        assert (
+            html(body_t, app_state=None)
+            == '<body><div class="hdr theme-default"><h1>App</h1></div></body>'
+        )

--- a/tdom/processor_extension_test.py
+++ b/tdom/processor_extension_test.py
@@ -6,6 +6,9 @@ from .processor import (
     Attribute,
     ComponentProcessor,
     IComponentProcessor,
+    IFactoryComponent,
+    IFactoryMiddlewareComponent,
+    IFunctionComponent,
     ProcessContext,
     TemplateProcessor,
 )
@@ -21,15 +24,11 @@ AppStateCtx: ContextVar[AppState | None] = ContextVar("AppStateCtx", default=Non
 
 
 class TestComponentProcessor:
-    @dataclass
-    class Body:
-        children: Template
-
-        def __call__(self) -> Template:
-            return t"<body>{self.children}</body>"
+    def Body(self, children: Template) -> Template:
+        return t"<body>{children}</body>"
 
     @dataclass
-    class Header:
+    class Header(IFactoryComponent):
         children: Template
 
         app_state: AppState
@@ -85,6 +84,7 @@ class TestComponentProcessor:
 
     def test_injected_app_state(self):
         name = "App"
+        assert isinstance(self.Body, IFunctionComponent)
         body_t = (
             t"<{self.Body}><{self.Header}><h1>{name}</h1></{self.Header}></{self.Body}>"
         )
@@ -110,7 +110,7 @@ ModeCtx: ContextVar[str] = ContextVar("ModeCtx")
 
 class TestMiddlewareGetContextValues:
     @dataclass
-    class ThemeProvider:
+    class ThemeProvider(IFactoryMiddlewareComponent):
         theme_name: str
 
         children: Template
@@ -130,7 +130,7 @@ class TestMiddlewareGetContextValues:
             return context_values
 
     @dataclass
-    class ThemeDisplay:
+    class ThemeDisplay(IFactoryComponent):
         theme_name: str
 
         mode: str | None = None

--- a/tdom/processor_extension_test.py
+++ b/tdom/processor_extension_test.py
@@ -1,0 +1,168 @@
+import typing as t
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from string.templatelib import Template
+
+from .processor import (
+    Attribute,
+    ComponentCallable,
+    ComponentObject,
+    ComponentProcessor,
+    IComponentProcessor,
+    ProcessContext,
+    TemplateProcessor,
+)
+from .tnodes import TAttribute
+
+
+class ISimpleRequest(t.Protocol):
+    def make_url(self, path: str) -> str: ...
+
+
+@dataclass()
+class SystemState:
+    request: ISimpleRequest
+    components: dict[object, ComponentCallable] = field(
+        default_factory=dict
+    )  # t.Type[t.Protocol]
+
+
+SystemCtx: ContextVar[SystemState | None] = ContextVar("SystemCtx", default=None)
+
+
+class TestComponentProcessor:
+    @dataclass
+    class SimpleRequest(ISimpleRequest):
+        scheme: str
+        host: str
+
+        def make_url(self, path: str) -> str:
+            # @NOTE: Don't actually make URLs this way, this is just an example.
+            return f"{self.scheme}://{self.host}/{path.lstrip('/')}"
+
+    class IHeader(t.Protocol):
+        children: Template
+        hdr_class: str
+
+        def __call__(self) -> Template: ...
+
+    @dataclass
+    class Header(IHeader):
+        children: Template
+
+        hdr_class: str = "hdr"
+
+        def __call__(self) -> Template:
+            return t"<div class={self.hdr_class}>{self.children}</div>"
+
+    class INav(t.Protocol):
+        request: ISimpleRequest
+
+        links: tuple[tuple[str, str], ...]
+
+        def __call__(self) -> Template: ...
+
+    @dataclass
+    class Nav(INav):
+        request: ISimpleRequest
+
+        links: tuple[tuple[str, str], ...] = ()
+
+        nav_class: str = "nav"
+
+        def _make_nav_links(self) -> list[Template]:
+            return [
+                t"<a href={self.request.make_url(href)}>{label}</a>"
+                for label, href in self.links
+            ]
+
+        def __call__(self) -> Template:
+            return t"<div class={self.nav_class}>{self._make_nav_links()}</div>"
+
+    @dataclass
+    class Logo:  # NO DI / NO Protocol
+        logo_fallback: str = "LOGO"
+
+        logo_class: str = "logo"
+
+        def __call__(self) -> Template:
+            return t"<span class={self.logo_class}>{self.logo_fallback}</span>"
+
+    @dataclass
+    class SystemComponentProcessor(IComponentProcessor):
+        default_component_processor_api: IComponentProcessor = field(
+            default_factory=ComponentProcessor
+        )
+
+        def process(
+            self,
+            template: Template,
+            last_ctx: ProcessContext,
+            component_callable: object,
+            attrs: tuple[TAttribute, ...],
+            component_template: Template,
+            provided_attrs: tuple[Attribute, ...] = (),
+        ) -> tuple[Template, ComponentObject | None]:
+            from inspect import isclass
+
+            system_ctx = SystemCtx.get()
+            if (
+                system_ctx is not None
+                and isclass(component_callable)
+                and t.is_protocol(component_callable)
+                and component_callable in system_ctx.components
+            ):
+                # Use the protocol to get the concrete component factory.
+                # @NOTE: This is using the contextvars.ContextVar to
+                # get this information but maybe in the future we'd have
+                # a way to get ctx directly from a parameter.
+                component_callable = system_ctx.components[component_callable]
+
+            # Also pass in system provided attributes to EVERY
+            # component (but it will only be used during the call if it needed.
+            # @NOTE: This is using the contextvars.ContextVar to
+            # get this information but maybe in the future we'd have
+            # a way to get ctx directly from a parameter.
+            if system_ctx is not None:
+                system_attrs = (("request", system_ctx.request),)
+                provided_attrs = provided_attrs + system_attrs
+
+            # @NOTE: We mostly just put the correct values in the right places
+            # to perform the default component processing.
+            # - `component_callable` is now the actual concrete implementation
+            # - `provided_attrs` now has attrs that might not be in the template
+            # So we can just wrap the default processor and let it do all the
+            # work. BUT... if we wanted to just replace the invocation we could
+            # do that and just return the correct thing ourselves.
+            return self.default_component_processor_api.process(
+                template=template,
+                last_ctx=last_ctx,
+                component_callable=component_callable,
+                attrs=attrs,
+                component_template=component_template,
+                provided_attrs=provided_attrs,
+            )
+
+    def test_replacement(self):
+        sys_comp_processor = self.SystemComponentProcessor()
+
+        tp = TemplateProcessor(component_processor_api=sys_comp_processor)
+
+        # Mapping established beforehand.
+        components: dict[object, ComponentCallable] = {  # t.Type[t.Protocol]
+            self.IHeader: self.Header,
+            self.INav: self.Nav,
+        }
+        current_request = self.SimpleRequest(scheme="https", host="www.example.com")
+        with SystemCtx.set(SystemState(components=components, request=current_request)):
+            links = [("Home", "/"), ("About", "/about")]
+            header_t = t"<{self.IHeader}><{self.Logo} /><{self.INav} links={links} /></{self.IHeader}>"
+            assert tp.process(header_t, assume_ctx=ProcessContext()) == (
+                '<div class="hdr">'
+                '<span class="logo">LOGO</span>'
+                '<div class="nav">'
+                '<a href="https://www.example.com/">Home</a>'
+                '<a href="https://www.example.com/about">About</a>'
+                "</div>"
+                "</div>"
+            )

--- a/tdom/processor_extension_test.py
+++ b/tdom/processor_extension_test.py
@@ -54,7 +54,7 @@ class TestComponentProcessor:
             attrs: tuple[TAttribute, ...],
             component_template: Template,
             provided_attrs: tuple[Attribute, ...] = (),
-        ) -> Template:
+        ) -> Template | tuple[Template, object]:
             # For now we just make the app state available to EVERY component
             # a smarter strategy would be to only include it if asked via
             # the callable's signature or even the callable's typehints.
@@ -100,4 +100,97 @@ class TestComponentProcessor:
         assert (
             html(body_t, app_state=None)
             == '<body><div class="hdr theme-default"><h1>App</h1></div></body>'
+        )
+
+
+ThemeCtx: ContextVar[str] = ContextVar("ThemeCtx")
+
+ModeCtx: ContextVar[str] = ContextVar("ModeCtx")
+
+
+class TestMiddlewareGetContextValues:
+    @dataclass
+    class ThemeProvider:
+        theme_name: str
+
+        children: Template
+
+        mode: str | None = None
+
+        def __call__(self) -> tuple[Template, object]:
+            # Hit em' with another div...
+            result_t = t"<div>{self.children}</div>"
+            middleware_api = self
+            return result_t, middleware_api
+
+        def get_context_values(self) -> tuple[tuple[ContextVar, str], ...]:
+            context_values = ((ThemeCtx, self.theme_name),)
+            if self.mode is not None:
+                context_values += ((ModeCtx, self.mode),)
+            return context_values
+
+    @dataclass
+    class ThemeDisplay:
+        theme_name: str
+
+        mode: str | None = None
+
+        def __call__(self) -> Template:
+            sep = ":" if self.mode else None
+            return t"<span>{self.theme_name}{sep}{self.mode}</span>"
+
+    def _make_html(
+        self, default_theme_name: str = "theme-default", default_mode: str = "mode-dark"
+    ):
+
+        tp = TemplateProcessor()
+
+        def _html(template: Template, assume_ctx: ProcessContext | None = None):
+            if assume_ctx is None:
+                assume_ctx = ProcessContext()
+            with ThemeCtx.set(default_theme_name), ModeCtx.set(default_mode):
+                return tp.process(template, assume_ctx)
+
+        return _html
+
+    def _theme_name(self):
+        return ThemeCtx.get()
+
+    def _mode(self):
+        return ModeCtx.get()
+
+    def test_default(self):
+        html = self._make_html()
+        assert (
+            html(t"<{self.ThemeDisplay} theme_name={self._theme_name:callback} />")
+            == "<span>theme-default</span>"
+        )
+
+    def test_provider(self):
+        html = self._make_html()
+        child_t = t"<{self.ThemeDisplay} theme_name={self._theme_name:callback} />"
+        assert (
+            html(
+                t"<{self.ThemeProvider} theme_name='theme-pycon'>{child_t}</{self.ThemeProvider}>"
+            )
+            == "<div><span>theme-pycon</span></div>"
+        )
+
+    def test_provider_scope(self):
+        html = self._make_html()
+        child_t = t"<{self.ThemeDisplay} theme_name={self._theme_name:callback} />"
+        wrapped_t = t"<{self.ThemeProvider} theme_name='theme-pycon'>{child_t}</{self.ThemeProvider}>"
+        assert (
+            html(wrapped_t + child_t)
+            == "<div><span>theme-pycon</span></div><span>theme-default</span>"
+        )
+
+    def test_two_cvars(self):
+        html = self._make_html()
+        child_t = t"<{self.ThemeDisplay} theme_name={self._theme_name:callback} mode={self._mode:callback} />"
+        assert (
+            html(
+                t"<{self.ThemeProvider} theme_name='theme-pycon' mode='mode-light'>{child_t}</{self.ThemeProvider}>"
+            )
+            == "<div><span>theme-pycon:mode-light</span></div>"
         )

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -23,7 +23,6 @@ from .processor import (
     TemplateParserProxy,
     TemplateProcessor,
     _make_default_template_processor,
-    make_ctx,
 )
 from .processor import (
     _prep_component_kwargs as prep_component_kwargs,
@@ -1979,7 +1978,7 @@ class TestComponentProcessor:
         with SystemCtx.set(SystemState(components=components, request=current_request)):
             links = [("Home", "/"), ("About", "/about")]
             header_t = t"<{self.IHeader}><{self.Logo} /><{self.INav} links={links} /></{self.IHeader}>"
-            assert tp.process(header_t) == (
+            assert tp.process(header_t, assume_ctx=ProcessContext()) == (
                 '<div class="hdr">'
                 '<span class="logo">LOGO</span>'
                 '<div class="nav">'

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -1835,6 +1835,7 @@ class TestComponentErrors:
 
 @dataclass()
 class SystemState:
+    request: ISimpleRequest
     components: dict[object, ComponentCallable] = field(
         default_factory=dict
     )  # t.Type[t.Protocol]
@@ -1843,7 +1844,20 @@ class SystemState:
 SystemCtx: ContextVar[SystemState | None] = ContextVar("SystemCtx", default=None)
 
 
+class ISimpleRequest(t.Protocol):
+    def make_url(self, path: str) -> str: ...
+
+
 class TestComponentProcessor:
+    @dataclass
+    class SimpleRequest(ISimpleRequest):
+        scheme: str
+        host: str
+
+        def make_url(self, path: str) -> str:
+            # @NOTE: Don't actually make URLs this way, this is just an example.
+            return f"{self.scheme}://{self.host}/{path.lstrip('/')}"
+
     class IHeader(t.Protocol):
         children: Template
         hdr_class: str
@@ -1860,18 +1874,25 @@ class TestComponentProcessor:
             return t"<div class={self.hdr_class}>{self.children}</div>"
 
     class INav(t.Protocol):
+        request: ISimpleRequest
+
         links: tuple[tuple[str, str], ...]
 
         def __call__(self) -> Template: ...
 
     @dataclass
     class Nav(INav):
+        request: ISimpleRequest
+
         links: tuple[tuple[str, str], ...] = ()
 
         nav_class: str = "nav"
 
         def _make_nav_links(self) -> list[Template]:
-            return [t"<a href={href}>{label}</a>" for label, href in self.links]
+            return [
+                t"<a href={self.request.make_url(href)}>{label}</a>"
+                for label, href in self.links
+            ]
 
         def __call__(self) -> Template:
             return t"<div class={self.nav_class}>{self._make_nav_links()}</div>"
@@ -1909,7 +1930,28 @@ class TestComponentProcessor:
                 and t.is_protocol(component_callable)
                 and component_callable in system_ctx.components
             ):
+                # Use the protocol to get the concrete component factory.
+                # @NOTE: This is using the contextvars.ContextVar to
+                # get this information but maybe in the future we'd have
+                # a way to get ctx directly from a parameter.
                 component_callable = system_ctx.components[component_callable]
+
+            # Also pass in system provided attributes to EVERY
+            # component (but it will only be used during the call if it needed.
+            # @NOTE: This is using the contextvars.ContextVar to
+            # get this information but maybe in the future we'd have
+            # a way to get ctx directly from a parameter.
+            if system_ctx is not None:
+                system_attrs = (("request", system_ctx.request),)
+                provided_attrs = provided_attrs + system_attrs
+
+            # @NOTE: We mostly just put the correct values in the right places
+            # to perform the default component processing.
+            # - `component_callable` is now the actual concrete implementation
+            # - `provided_attrs` now has attrs that might not be in the template
+            # So we can just wrap the default processor and let it do all the
+            # work. BUT... if we wanted to just replace the invocation we could
+            # do that and just return the correct thing ourselves.
             return self.default_component_processor_api.process(
                 template=template,
                 last_ctx=last_ctx,
@@ -1929,11 +1971,18 @@ class TestComponentProcessor:
             self.IHeader: self.Header,
             self.INav: self.Nav,
         }
-        with SystemCtx.set(SystemState(components=components)):
+        current_request = self.SimpleRequest(scheme="https", host="www.example.com")
+        with SystemCtx.set(SystemState(components=components, request=current_request)):
             links = [("Home", "/"), ("About", "/about")]
             header_t = t"<{self.IHeader}><{self.Logo} /><{self.INav} links={links} /></{self.IHeader}>"
             assert tp.process(header_t) == (
-                '<div class="hdr"><span class="logo">LOGO</span><div class="nav"><a href="/">Home</a><a href="/about">About</a></div></div>'
+                '<div class="hdr">'
+                '<span class="logo">LOGO</span>'
+                '<div class="nav">'
+                '<a href="https://www.example.com/">Home</a>'
+                '<a href="https://www.example.com/about">About</a>'
+                "</div>"
+                "</div>"
             )
 
 

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -1,8 +1,7 @@
 import datetime
 import typing as t
 from collections.abc import Callable
-from contextvars import ContextVar
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from itertools import chain, product
 from string.templatelib import Template
 
@@ -13,12 +12,7 @@ from markupsafe import escape as markupsafe_escape
 from .callables import get_callable_info
 from .escaping import escape_html_text
 from .processor import (
-    Attribute,
     CachedTemplateParserProxy,
-    ComponentCallable,
-    ComponentObject,
-    ComponentProcessor,
-    IComponentProcessor,
     ProcessContext,
     TemplateParserProxy,
     TemplateProcessor,
@@ -28,7 +22,6 @@ from .processor import (
     _prep_component_kwargs as prep_component_kwargs,
 )
 from .protocols import HasHTMLDunder
-from .tnodes import TAttribute
 
 processor_api = _make_default_template_processor(
     parser_api=TemplateParserProxy(),  # do not use cache
@@ -1834,159 +1827,6 @@ class TestComponentErrors:
             TypeError, match="Component object must return Template when called:"
         ):
             _ = html(t"<{BadFactoryComp}>Hello</{BadFactoryComp}>")
-
-
-@dataclass()
-class SystemState:
-    request: ISimpleRequest
-    components: dict[object, ComponentCallable] = field(
-        default_factory=dict
-    )  # t.Type[t.Protocol]
-
-
-SystemCtx: ContextVar[SystemState | None] = ContextVar("SystemCtx", default=None)
-
-
-class ISimpleRequest(t.Protocol):
-    def make_url(self, path: str) -> str: ...
-
-
-class TestComponentProcessor:
-    @dataclass
-    class SimpleRequest(ISimpleRequest):
-        scheme: str
-        host: str
-
-        def make_url(self, path: str) -> str:
-            # @NOTE: Don't actually make URLs this way, this is just an example.
-            return f"{self.scheme}://{self.host}/{path.lstrip('/')}"
-
-    class IHeader(t.Protocol):
-        children: Template
-        hdr_class: str
-
-        def __call__(self) -> Template: ...
-
-    @dataclass
-    class Header(IHeader):
-        children: Template
-
-        hdr_class: str = "hdr"
-
-        def __call__(self) -> Template:
-            return t"<div class={self.hdr_class}>{self.children}</div>"
-
-    class INav(t.Protocol):
-        request: ISimpleRequest
-
-        links: tuple[tuple[str, str], ...]
-
-        def __call__(self) -> Template: ...
-
-    @dataclass
-    class Nav(INav):
-        request: ISimpleRequest
-
-        links: tuple[tuple[str, str], ...] = ()
-
-        nav_class: str = "nav"
-
-        def _make_nav_links(self) -> list[Template]:
-            return [
-                t"<a href={self.request.make_url(href)}>{label}</a>"
-                for label, href in self.links
-            ]
-
-        def __call__(self) -> Template:
-            return t"<div class={self.nav_class}>{self._make_nav_links()}</div>"
-
-    @dataclass
-    class Logo:  # NO DI / NO Protocol
-        logo_fallback: str = "LOGO"
-
-        logo_class: str = "logo"
-
-        def __call__(self) -> Template:
-            return t"<span class={self.logo_class}>{self.logo_fallback}</span>"
-
-    @dataclass
-    class SystemComponentProcessor(IComponentProcessor):
-        default_component_processor_api: IComponentProcessor = field(
-            default_factory=ComponentProcessor
-        )
-
-        def process(
-            self,
-            template: Template,
-            last_ctx: ProcessContext,
-            component_callable: object,
-            attrs: tuple[TAttribute, ...],
-            component_template: Template,
-            provided_attrs: tuple[Attribute, ...] = (),
-        ) -> tuple[Template, ComponentObject | None]:
-            from inspect import isclass
-
-            system_ctx = SystemCtx.get()
-            if (
-                system_ctx is not None
-                and isclass(component_callable)
-                and t.is_protocol(component_callable)
-                and component_callable in system_ctx.components
-            ):
-                # Use the protocol to get the concrete component factory.
-                # @NOTE: This is using the contextvars.ContextVar to
-                # get this information but maybe in the future we'd have
-                # a way to get ctx directly from a parameter.
-                component_callable = system_ctx.components[component_callable]
-
-            # Also pass in system provided attributes to EVERY
-            # component (but it will only be used during the call if it needed.
-            # @NOTE: This is using the contextvars.ContextVar to
-            # get this information but maybe in the future we'd have
-            # a way to get ctx directly from a parameter.
-            if system_ctx is not None:
-                system_attrs = (("request", system_ctx.request),)
-                provided_attrs = provided_attrs + system_attrs
-
-            # @NOTE: We mostly just put the correct values in the right places
-            # to perform the default component processing.
-            # - `component_callable` is now the actual concrete implementation
-            # - `provided_attrs` now has attrs that might not be in the template
-            # So we can just wrap the default processor and let it do all the
-            # work. BUT... if we wanted to just replace the invocation we could
-            # do that and just return the correct thing ourselves.
-            return self.default_component_processor_api.process(
-                template=template,
-                last_ctx=last_ctx,
-                component_callable=component_callable,
-                attrs=attrs,
-                component_template=component_template,
-                provided_attrs=provided_attrs,
-            )
-
-    def test_replacement(self):
-        sys_comp_processor = self.SystemComponentProcessor()
-
-        tp = TemplateProcessor(component_processor_api=sys_comp_processor)
-
-        # Mapping established beforehand.
-        components: dict[object, ComponentCallable] = {  # t.Type[t.Protocol]
-            self.IHeader: self.Header,
-            self.INav: self.Nav,
-        }
-        current_request = self.SimpleRequest(scheme="https", host="www.example.com")
-        with SystemCtx.set(SystemState(components=components, request=current_request)):
-            links = [("Home", "/"), ("About", "/about")]
-            header_t = t"<{self.IHeader}><{self.Logo} /><{self.INav} links={links} /></{self.IHeader}>"
-            assert tp.process(header_t, assume_ctx=ProcessContext()) == (
-                '<div class="hdr">'
-                '<span class="logo">LOGO</span>'
-                '<div class="nav">'
-                '<a href="https://www.example.com/">Home</a>'
-                '<a href="https://www.example.com/about">About</a>'
-                "</div>"
-                "</div>"
-            )
 
 
 def test_integration_basic():

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -1801,9 +1801,7 @@ class TestComponentErrors:
         with pytest.raises(TypeError):
             _ = html(t"<{OpenTag}>Hello</{CloseTag}>")
 
-    @pytest.mark.parametrize(
-        "bad_value", ("", "text", None, 1, ("tuple", "of", "strs"))
-    )
+    @pytest.mark.parametrize("bad_value", ("", "text", None, 1, ("list", "of", "strs")))
     def test_function_component_returns_nontemplate_fails(self, bad_value):
         def BadFunctionComp(children: Template):
             return bad_value
@@ -1813,9 +1811,7 @@ class TestComponentErrors:
         ):
             _ = html(t"<{BadFunctionComp}>Hello</{BadFunctionComp}>")
 
-    @pytest.mark.parametrize(
-        "bad_value", ("", "text", None, 1, ("tuple", "of", "strs"))
-    )
+    @pytest.mark.parametrize("bad_value", ("", "text", None, 1, ["list", "of", "strs"]))
     def test_component_object_returns_nontemplate_fails(self, bad_value):
         def BadFactoryComp(children: Template):
             def component_object():
@@ -1824,7 +1820,40 @@ class TestComponentErrors:
             return component_object
 
         with pytest.raises(
-            TypeError, match="Component object must return Template when called:"
+            TypeError,
+            match="Component object must return Template or 2-tuple when called:",
+        ):
+            _ = html(t"<{BadFactoryComp}>Hello</{BadFactoryComp}>")
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        (
+            (t"",),  # Too short
+            (t"", None, None),  # Too long
+        ),
+    )
+    def test_component_object_returns_mislengthed_tuple_fails(self, bad_value):
+        def BadFactoryComp(children: Template):
+            def component_object():
+                return bad_value
+
+            return component_object
+
+        with pytest.raises(
+            ValueError, match="Component object returned tuple with length != 2"
+        ):
+            _ = html(t"<{BadFactoryComp}>Hello</{BadFactoryComp}>")
+
+    def test_component_object_returns_nontemplate_in_2tuple_fails(self):
+        def BadFactoryComp(children: Template):
+            def component_object():
+                return (None, t"")
+
+            return component_object
+
+        with pytest.raises(
+            TypeError,
+            match="Component object returned unxpected type in first entry of 2-tuple",
         ):
             _ = html(t"<{BadFactoryComp}>Hello</{BadFactoryComp}>")
 

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -1816,7 +1816,9 @@ class TestComponentErrors:
         def BadFunctionComp(children: Template):
             return bad_value
 
-        with pytest.raises(TypeError, match="Unknown component return value:"):
+        with pytest.raises(
+            TypeError, match="Component callable must return Template or Callable:"
+        ):
             _ = html(t"<{BadFunctionComp}>Hello</{BadFunctionComp}>")
 
     @pytest.mark.parametrize(
@@ -1829,7 +1831,9 @@ class TestComponentErrors:
 
             return component_object
 
-        with pytest.raises(TypeError, match="Unknown component return value:"):
+        with pytest.raises(
+            TypeError, match="Component object must return Template when called:"
+        ):
             _ = html(t"<{BadFactoryComp}>Hello</{BadFactoryComp}>")
 
 
@@ -1916,11 +1920,11 @@ class TestComponentProcessor:
             self,
             template: Template,
             last_ctx: ProcessContext,
-            component_callable: ComponentCallable,  # @NOTE: What should this be?
+            component_callable: object,
             attrs: tuple[TAttribute, ...],
             component_template: Template,
             provided_attrs: tuple[Attribute, ...] = (),
-        ) -> ComponentObject | Template:
+        ) -> tuple[Template, ComponentObject | None]:
             from inspect import isclass
 
             system_ctx = SystemCtx.get()

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -1,6 +1,7 @@
 import datetime
 import typing as t
 from collections.abc import Callable
+from contextvars import ContextVar
 from dataclasses import dataclass
 from itertools import chain, product
 from string.templatelib import Template
@@ -13,15 +14,21 @@ from .callables import get_callable_info
 from .escaping import escape_html_text
 from .processor import (
     CachedTemplateParserProxy,
+    ComponentCallable,
+    ComponentObject,
+    IComponentProcessor,
     ProcessContext,
     TemplateParserProxy,
     TemplateProcessor,
     _make_default_template_processor,
+    _resolve_t_attrs,
+    make_ctx,
 )
 from .processor import (
     _prep_component_kwargs as prep_component_kwargs,
 )
 from .protocols import HasHTMLDunder
+from .tnodes import TAttribute
 
 processor_api = _make_default_template_processor(
     parser_api=TemplateParserProxy(),  # do not use cache
@@ -1823,6 +1830,62 @@ class TestComponentErrors:
 
         with pytest.raises(TypeError, match="Unknown component return value:"):
             _ = html(t"<{BadFactoryComp}>Hello</{BadFactoryComp}>")
+
+
+@dataclass()
+class SystemState:
+    path_prefix: str
+
+
+SystemCtx: ContextVar[SystemState | None] = ContextVar("SystemCtx", default=None)
+
+
+class TestComponentProcessor:
+    class SystemComponentProcessor(IComponentProcessor):
+        def process(
+            self,
+            template: Template,
+            last_ctx: ProcessContext,
+            component_callable: ComponentCallable,
+            attrs: tuple[TAttribute, ...],
+            component_template: Template,
+        ) -> ComponentObject | Template:
+
+            system_ctx = SystemCtx.get()
+            if system_ctx is not None:
+                provided_attrs = (("system_path_prefix", system_ctx.path_prefix),)
+            else:
+                provided_attrs = ()
+            kwargs = prep_component_kwargs(
+                get_callable_info(component_callable),
+                _resolve_t_attrs(attrs, template.interpolations),
+                children=component_template,
+                provided_attrs=provided_attrs,
+            )
+            return component_callable(**kwargs)
+
+    def test_replacement(self):
+        def Header(children: Template) -> Template:
+            return t"<div class=hdr>{children}</div>"
+
+        def Nav(system_path_prefix: str = "") -> Template:
+            about_url = f"{system_path_prefix.rstrip('/')}/about"
+            return t"<div class=nav><a href={about_url}>About</a></div>"
+
+        sys_comp_processor = self.SystemComponentProcessor()
+
+        tp = TemplateProcessor(component_processor_api=sys_comp_processor)
+
+        assert tp.process(t"<{Header}><{Nav} /></{Header}>") == (
+            '<div class="hdr"><div class="nav"><a href="/about">About</a></div></div>'
+        )
+        with SystemCtx.set(SystemState(path_prefix="https://example.com/")):
+            assert tp.process(t"<{Header}><{Nav} /></{Header}>") == (
+                '<div class="hdr"><div class="nav"><a href="https://example.com/about">About</a></div></div>'
+            )
+            assert tp.process(t"<{Header}><{Nav} /></{Header}>") != (
+                '<div class="hdr"><div class="nav"><a href="/about">About</a></div></div>'
+            )
 
 
 def test_integration_basic():

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -2,7 +2,7 @@ import datetime
 import typing as t
 from collections.abc import Callable
 from contextvars import ContextVar
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from itertools import chain, product
 from string.templatelib import Template
 
@@ -13,15 +13,16 @@ from markupsafe import escape as markupsafe_escape
 from .callables import get_callable_info
 from .escaping import escape_html_text
 from .processor import (
+    Attribute,
     CachedTemplateParserProxy,
     ComponentCallable,
     ComponentObject,
+    ComponentProcessor,
     IComponentProcessor,
     ProcessContext,
     TemplateParserProxy,
     TemplateProcessor,
     _make_default_template_processor,
-    _resolve_t_attrs,
     make_ctx,
 )
 from .processor import (
@@ -1834,57 +1835,105 @@ class TestComponentErrors:
 
 @dataclass()
 class SystemState:
-    path_prefix: str
+    components: dict[object, ComponentCallable] = field(
+        default_factory=dict
+    )  # t.Type[t.Protocol]
 
 
 SystemCtx: ContextVar[SystemState | None] = ContextVar("SystemCtx", default=None)
 
 
 class TestComponentProcessor:
+    class IHeader(t.Protocol):
+        children: Template
+        hdr_class: str
+
+        def __call__(self) -> Template: ...
+
+    @dataclass
+    class Header(IHeader):
+        children: Template
+
+        hdr_class: str = "hdr"
+
+        def __call__(self) -> Template:
+            return t"<div class={self.hdr_class}>{self.children}</div>"
+
+    class INav(t.Protocol):
+        links: tuple[tuple[str, str], ...]
+
+        def __call__(self) -> Template: ...
+
+    @dataclass
+    class Nav(INav):
+        links: tuple[tuple[str, str], ...] = ()
+
+        nav_class: str = "nav"
+
+        def _make_nav_links(self) -> list[Template]:
+            return [t"<a href={href}>{label}</a>" for label, href in self.links]
+
+        def __call__(self) -> Template:
+            return t"<div class={self.nav_class}>{self._make_nav_links()}</div>"
+
+    @dataclass
+    class Logo:  # NO DI / NO Protocol
+        logo_fallback: str = "LOGO"
+
+        logo_class: str = "logo"
+
+        def __call__(self) -> Template:
+            return t"<span class={self.logo_class}>{self.logo_fallback}</span>"
+
+    @dataclass
     class SystemComponentProcessor(IComponentProcessor):
+        default_component_processor_api: IComponentProcessor = field(
+            default_factory=ComponentProcessor
+        )
+
         def process(
             self,
             template: Template,
             last_ctx: ProcessContext,
-            component_callable: ComponentCallable,
+            component_callable: ComponentCallable,  # @NOTE: What should this be?
             attrs: tuple[TAttribute, ...],
             component_template: Template,
+            provided_attrs: tuple[Attribute, ...] = (),
         ) -> ComponentObject | Template:
+            from inspect import isclass
 
             system_ctx = SystemCtx.get()
-            if system_ctx is not None:
-                provided_attrs = (("system_path_prefix", system_ctx.path_prefix),)
-            else:
-                provided_attrs = ()
-            kwargs = prep_component_kwargs(
-                get_callable_info(component_callable),
-                _resolve_t_attrs(attrs, template.interpolations),
-                children=component_template,
+            if (
+                system_ctx is not None
+                and isclass(component_callable)
+                and t.is_protocol(component_callable)
+                and component_callable in system_ctx.components
+            ):
+                component_callable = system_ctx.components[component_callable]
+            return self.default_component_processor_api.process(
+                template=template,
+                last_ctx=last_ctx,
+                component_callable=component_callable,
+                attrs=attrs,
+                component_template=component_template,
                 provided_attrs=provided_attrs,
             )
-            return component_callable(**kwargs)
 
     def test_replacement(self):
-        def Header(children: Template) -> Template:
-            return t"<div class=hdr>{children}</div>"
-
-        def Nav(system_path_prefix: str = "") -> Template:
-            about_url = f"{system_path_prefix.rstrip('/')}/about"
-            return t"<div class=nav><a href={about_url}>About</a></div>"
-
         sys_comp_processor = self.SystemComponentProcessor()
 
         tp = TemplateProcessor(component_processor_api=sys_comp_processor)
 
-        assert tp.process(t"<{Header}><{Nav} /></{Header}>") == (
-            '<div class="hdr"><div class="nav"><a href="/about">About</a></div></div>'
-        )
-        with SystemCtx.set(SystemState(path_prefix="https://example.com/")):
-            assert tp.process(t"<{Header}><{Nav} /></{Header}>") == (
-                '<div class="hdr"><div class="nav"><a href="https://example.com/about">About</a></div></div>'
-            )
-            assert tp.process(t"<{Header}><{Nav} /></{Header}>") != (
-                '<div class="hdr"><div class="nav"><a href="/about">About</a></div></div>'
+        # Mapping established beforehand.
+        components: dict[object, ComponentCallable] = {  # t.Type[t.Protocol]
+            self.IHeader: self.Header,
+            self.INav: self.Nav,
+        }
+        with SystemCtx.set(SystemState(components=components)):
+            links = [("Home", "/"), ("About", "/about")]
+            header_t = t"<{self.IHeader}><{self.Logo} /><{self.INav} links={links} /></{self.IHeader}>"
+            assert tp.process(header_t) == (
+                '<div class="hdr"><span class="logo">LOGO</span><div class="nav"><a href="/">Home</a><a href="/about">About</a></div></div>'
             )
 
 

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -1801,13 +1801,31 @@ class TestComponentErrors:
         with pytest.raises(TypeError):
             _ = html(t"<{OpenTag}>Hello</{CloseTag}>")
 
-    @pytest.mark.parametrize("bad_value", ("", "text", None, 1, ("list", "of", "strs")))
+    @pytest.mark.parametrize("bad_value", ("", "text", None, 1))
     def test_function_component_returns_nontemplate_fails(self, bad_value):
         def BadFunctionComp(children: Template):
             return bad_value
 
         with pytest.raises(
-            TypeError, match="Component callable must return Template or Callable:"
+            TypeError,
+            match="Component callable must return Template, 2-tuple or Callable:",
+        ):
+            _ = html(t"<{BadFunctionComp}>Hello</{BadFunctionComp}>")
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        (
+            (t"",),
+            (t"", None, None),
+        ),
+    )
+    def test_function_object_returns_mislengthed_tuple_fails(self, bad_value):
+        def BadFunctionComp(children: Template):
+            return bad_value
+
+        with pytest.raises(
+            TypeError,
+            match="Component callable returned tuple with length != 2:",
         ):
             _ = html(t"<{BadFunctionComp}>Hello</{BadFunctionComp}>")
 
@@ -1840,7 +1858,7 @@ class TestComponentErrors:
             return component_object
 
         with pytest.raises(
-            ValueError, match="Component object returned tuple with length != 2"
+            TypeError, match="Component object returned tuple with length != 2"
         ):
             _ = html(t"<{BadFactoryComp}>Hello</{BadFactoryComp}>")
 


### PR DESCRIPTION
This should be stacked on #118 

- ComponentProcessor(s) can now return either `Template` or a 2-tuple of `Template` and a "middleware" providing `object`.
- Only "middleware" currently supported is the ability to set context variable values that affect a component's children.
- Demos purpose of returning a "mystery" object back to the `TemplateProcessor`.