### PR TITLE
Move component children template extraction to the parser.

### DIFF
--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -177,13 +177,11 @@ class TemplateParser(HTMLParser):
             case OpenTComponent(
                 start_i_index=start_i_index,
                 attrs=attrs,
-                children=children,
             ):
                 return TComponent(
                     start_i_index=start_i_index,
                     end_i_index=endtag_i_index,
                     attrs=attrs,
-                    children=tuple(children),
                 )
 
     def validate_end_tag(self, tag: str, open_tag: OpenTag) -> int | None:

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -5,7 +5,7 @@ from string.templatelib import Interpolation, Template
 
 from .htmlspec import VOID_ELEMENTS
 from .placeholders import PlaceholderState
-from .template_utils import combine_template_refs
+from .template_utils import TemplateRef, combine_template_refs
 from .tnodes import (
     TAttribute,
     TComment,
@@ -40,7 +40,13 @@ class OpenTFragment:
 @dataclass
 class OpenTComponent:
     start_i_index: int
+    children_start_s_index: int
+    """The strings index where the component's children template starts."""
     attrs: tuple[TAttribute, ...]
+    # @NOTE: The `children` are discarded after parsing and are just used to
+    # track template consistency.  If the component is processed and
+    # returns its children template then that template will be
+    # re-parsed (or pulled from the cache).
     children: list[TNode] = field(default_factory=list)
 
 
@@ -55,7 +61,10 @@ class SourceTracker:
     # template itself in context and the relevant line/column underlined/etc.
 
     template: Template
+    # if i_index >= s_index, feeding an interpolation;
+    # otherwise, when i_index < s_index, feeding a string.
     i_index: int = -1  # The current interpolation index.
+    s_index: int = -1  # The current string index.
 
     @property
     def interpolations(self) -> tuple[Interpolation, ...]:
@@ -65,6 +74,10 @@ class SourceTracker:
         """Call before processing an interpolation to move to the next one."""
         self.i_index += 1
         return self.i_index
+
+    def advance_string(self) -> int:
+        self.s_index += 1
+        return self.s_index
 
     def get_expression(
         self, i_index: int, fallback_prefix: str = "interpolation"
@@ -160,8 +173,15 @@ class TemplateParser(HTMLParser):
         # component callable. We do not check this in the parser, instead
         # relying on higher layers to validate types and render correctly.
         i_index = tag_ref.i_indexes[0]
+        # The starting s_index of the component's children template. Note that
+        # this string either contains ">" or " />".  It might not be
+        # i_index + 1 because attributes WITHIN the component's tag might
+        # contain interpolations causing the i_index (and s_index) to advance
+        # arbitrarily.
+        children_start_s_index = self.get_source().s_index
         return OpenTComponent(
             start_i_index=i_index,
+            children_start_s_index=children_start_s_index,
             attrs=self.make_tattrs(attrs),
         )
 
@@ -176,11 +196,44 @@ class TemplateParser(HTMLParser):
                 return TFragment(children=tuple(children))
             case OpenTComponent(
                 start_i_index=start_i_index,
+                children_start_s_index=children_start_s_index,
                 attrs=attrs,
             ):
+                # Only go looking for a template if there is an actual endtag.
+                if start_i_index != endtag_i_index and endtag_i_index is not None:
+                    source = self.get_source()
+                    # @NOTE: This is an assumption that no interpolations
+                    # exist between the end tag interpolation itself and the
+                    # "</", ie. "</{end_i}>".
+                    children_end_s_index = endtag_i_index
+                    leading = source.template.strings[children_start_s_index]
+                    leading = leading[leading.find(">") + 1 :]
+                    if (
+                        children_start_s_index == children_end_s_index
+                    ):  # Entire children template is a string.
+                        leading = leading[: leading.rfind("</")]
+                        children_ref = TemplateRef(strings=(leading,), i_indexes=())
+                    else:
+                        trailing = source.template.strings[children_end_s_index]
+                        trailing = trailing[: trailing.rfind("</")]
+                        children_ref = TemplateRef(
+                            strings=(
+                                leading,
+                                *source.template.strings[
+                                    children_start_s_index + 1 : children_end_s_index
+                                ],
+                                trailing,
+                            ),
+                            i_indexes=tuple(
+                                range(children_start_s_index, children_end_s_index)
+                            ),
+                        )
+                else:
+                    children_ref = TemplateRef(strings=("",), i_indexes=())
                 return TComponent(
                     start_i_index=start_i_index,
                     end_i_index=endtag_i_index,
+                    children_ref=children_ref,
                     attrs=attrs,
                 )
 
@@ -329,6 +382,11 @@ class TemplateParser(HTMLParser):
     # Feeding and parsing
     # ------------------------------------------
 
+    def get_source(self) -> SourceTracker:
+        if self.source is None:
+            raise AssertionError("Source has not been initialized.")
+        return self.source
+
     def feed_str(self, s: str) -> None:
         """Feed a string part of a Template to the parser."""
         self.feed(s)
@@ -342,9 +400,11 @@ class TemplateParser(HTMLParser):
         assert self.source is None, "Did you forget to call reset?"
         self.source = SourceTracker(template)
         for i_index in range(len(template.interpolations)):
+            self.source.advance_string()
             self.feed_str(template.strings[i_index])
             self.source.advance_interpolation()
             self.feed_interpolation(i_index)
+        self.source.advance_string()
         self.feed_str(template.strings[-1])
 
     @staticmethod

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -4,7 +4,7 @@ from html.parser import HTMLParser
 from string.templatelib import Interpolation, Template
 
 from .htmlspec import VOID_ELEMENTS
-from .placeholders import PlaceholderState
+from .placeholders import PlaceholderConfig, PlaceholderState
 from .template_utils import TemplateRef, combine_template_refs
 from .tnodes import (
     TAttribute,
@@ -42,6 +42,8 @@ class OpenTComponent:
     start_i_index: int
     children_start_s_index: int
     """The strings index where the component's children template starts."""
+    offset_into_children_start_s: int
+    """The offset INTO the starting string where the component's children template starts."""
     attrs: tuple[TAttribute, ...]
     # @NOTE: The `children` are discarded after parsing and are just used to
     # track template consistency.  If the component is processed and
@@ -179,11 +181,69 @@ class TemplateParser(HTMLParser):
         # contain interpolations causing the i_index (and s_index) to advance
         # arbitrarily.
         children_start_s_index = self.get_source().s_index
+
+        # @NOTE: This must be called when the tag is handled since it is
+        # populated based on the most recently finished start tag. Otherwise
+        # the value will be out of sync.
+        starttag_text = self.get_starttag_text()
+        if starttag_text is None:
+            raise AssertionError(
+                f"Expected startag_text to be set when parsing component at {i_index}."
+            )
+
+        tattrs = self.make_tattrs(attrs)
+
+        offset_into_children_start_s = self.compute_offset_into_children_start_s(
+            start_i_index=i_index,
+            tattrs=tattrs,
+            config=self.placeholders.config,
+            starttag_text=starttag_text,
+        )
+
         return OpenTComponent(
             start_i_index=i_index,
             children_start_s_index=children_start_s_index,
-            attrs=self.make_tattrs(attrs),
+            offset_into_children_start_s=offset_into_children_start_s,
+            attrs=tattrs,
         )
+
+    def compute_offset_into_children_start_s(
+        self,
+        start_i_index: int,
+        tattrs: tuple[TAttribute, ...],
+        config: PlaceholderConfig,
+        starttag_text: str,
+    ) -> int:
+        """
+        Compute offset into "string" containing the start of children template.
+
+        This "string" also contains the trailing "string" portion of the
+        component's starttag.  Sometimes this is just ">" but other times this
+        contains literal attributes as well, ie. 'title="Title">...'.  Or in even
+        weirder cases the literal attribute can actually contain a ">" as well
+        such as 'title="1 > 0">...'. We want to determine how far INTO this string
+        from the beginning to skip over to get to the true start of the children's
+        template.
+
+        Examples:
+
+        <{Comp}></{Comp}> -- len(">")
+        <{Comp}>children</{Comp}> -- len(">")
+        <{Comp} title="1>0">children</{Comp}> -- len(' title="1>0">')
+        <{Comp} title="{'1>0'}">children</{Comp}> -- len('">')
+        """
+        # Collect indexes of each interpolation in the starttag text.
+        known: set[int] = {start_i_index}
+        for attr in tattrs:
+            if isinstance(attr, TInterpolatedAttribute):
+                known.add(attr.value_i_index)
+            elif isinstance(attr, TSpreadAttribute):
+                known.add(attr.i_index)
+            elif isinstance(attr, TTemplatedAttribute):
+                known.update(attr.value_ref.i_indexes)
+        temp_placeholders = PlaceholderState(known=known, config=config)
+        tag_ref = temp_placeholders.remove_placeholders(starttag_text)
+        return len(tag_ref.strings[-1])
 
     def finalize_tag(
         self, open_tag: OpenTag, endtag_i_index: int | None = None
@@ -197,45 +257,67 @@ class TemplateParser(HTMLParser):
             case OpenTComponent(
                 start_i_index=start_i_index,
                 children_start_s_index=children_start_s_index,
+                offset_into_children_start_s=offset_into_children_start_s,
                 attrs=attrs,
             ):
-                # Only go looking for a template if there is an actual endtag.
-                if start_i_index != endtag_i_index and endtag_i_index is not None:
-                    source = self.get_source()
-                    # @NOTE: This is an assumption that no interpolations
-                    # exist between the end tag interpolation itself and the
-                    # "</", ie. "</{end_i}>".
-                    children_end_s_index = endtag_i_index
-                    leading = source.template.strings[children_start_s_index]
-                    leading = leading[leading.find(">") + 1 :]
-                    if (
-                        children_start_s_index == children_end_s_index
-                    ):  # Entire children template is a string.
-                        leading = leading[: leading.rfind("</")]
-                        children_ref = TemplateRef(strings=(leading,), i_indexes=())
-                    else:
-                        trailing = source.template.strings[children_end_s_index]
-                        trailing = trailing[: trailing.rfind("</")]
-                        children_ref = TemplateRef(
-                            strings=(
-                                leading,
-                                *source.template.strings[
-                                    children_start_s_index + 1 : children_end_s_index
-                                ],
-                                trailing,
-                            ),
-                            i_indexes=tuple(
-                                range(children_start_s_index, children_end_s_index)
-                            ),
-                        )
-                else:
-                    children_ref = TemplateRef(strings=("",), i_indexes=())
+                children_ref = self.extract_component_children_ref(
+                    start_i_index=start_i_index,
+                    endtag_i_index=endtag_i_index,
+                    children_start_s_index=children_start_s_index,
+                    offset_into_children_start_s=offset_into_children_start_s,
+                    template=self.get_source().template,
+                )
                 return TComponent(
                     start_i_index=start_i_index,
                     end_i_index=endtag_i_index,
                     children_ref=children_ref,
                     attrs=attrs,
                 )
+
+    def extract_component_children_ref(
+        self,
+        start_i_index: int,
+        endtag_i_index: int | None,
+        children_start_s_index: int,
+        offset_into_children_start_s: int,
+        template: Template,
+    ) -> TemplateRef:
+        """
+        Extract the component children template from the entire template.
+
+        We use this template as a "key" into the cache to get the TNode tree.
+        """
+        # Only go looking for a template if there is an actual endtag.
+        if start_i_index != endtag_i_index and endtag_i_index is not None:
+            # @NOTE: This is an assumption that no interpolations
+            # exist between the end tag interpolation itself and the
+            # "</", ie. "</{end_i}>".
+            children_end_s_index = endtag_i_index
+            leading = template.strings[children_start_s_index]
+            leading = leading[offset_into_children_start_s:]
+            if (
+                children_start_s_index == children_end_s_index
+            ):  # Entire children template is a string.
+                leading = leading[: leading.rfind("</")]
+                children_ref = TemplateRef(strings=(leading,), i_indexes=())
+            else:
+                trailing = template.strings[children_end_s_index]
+                trailing = trailing[: trailing.rfind("</")]
+                children_ref = TemplateRef(
+                    strings=(
+                        leading,
+                        *template.strings[
+                            children_start_s_index + 1 : children_end_s_index
+                        ],
+                        trailing,
+                    ),
+                    i_indexes=tuple(
+                        range(children_start_s_index, children_end_s_index)
+                    ),
+                )
+        else:
+            children_ref = TemplateRef(strings=("",), i_indexes=())
+        return children_ref
 
     def validate_end_tag(self, tag: str, open_tag: OpenTag) -> int | None:
         """Validate that closing tag matches open tag. Return component end index if applicable."""

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -175,6 +175,10 @@ class TemplateParser(HTMLParser):
         # component callable. We do not check this in the parser, instead
         # relying on higher layers to validate types and render correctly.
         i_index = tag_ref.i_indexes[0]
+
+        # @NOTE: This must be stored when the tag is handled since it is
+        # set based on when the template parts are fed in and otherwise
+        # might be out of sync.
         # The starting s_index of the component's children template. Note that
         # this string either contains ">" or " />".  It might not be
         # i_index + 1 because attributes WITHIN the component's tag might
@@ -217,13 +221,12 @@ class TemplateParser(HTMLParser):
         """
         Compute offset into "string" containing the start of children template.
 
-        This "string" also contains the trailing "string" portion of the
-        component's starttag.  Sometimes this is just ">" but other times this
-        contains literal attributes as well, ie. 'title="Title">...'.  Or in even
-        weirder cases the literal attribute can actually contain a ">" as well
-        such as 'title="1 > 0">...'. We want to determine how far INTO this string
-        from the beginning to skip over to get to the true start of the children's
-        template.
+        @NOTE: This is to actually OFFLOAD work to the parser itself.  If we try
+        to "rebuild" the tag from the parse result we are bound to fail in some
+        way(s). We essentially re-run the placeholder process but with content
+        we KNOWN ends at the end of the starttag, ie. ">", because the parser
+        told us that is where it ends (rather than trying to scan for ">"
+        because ">" might be in literal tags).
 
         Examples:
 
@@ -232,8 +235,8 @@ class TemplateParser(HTMLParser):
         <{Comp} title="1>0">children</{Comp}> -- len(' title="1>0">')
         <{Comp} title="{'1>0'}">children</{Comp}> -- len('">')
         """
-        # Collect indexes of each interpolation in the starttag text.
-        known: set[int] = {start_i_index}
+        # Rebuild known interpolations in the starttag.
+        known: set[int] = {start_i_index}  # The component callable itself.
         for attr in tattrs:
             if isinstance(attr, TInterpolatedAttribute):
                 known.add(attr.value_i_index)
@@ -241,8 +244,17 @@ class TemplateParser(HTMLParser):
                 known.add(attr.i_index)
             elif isinstance(attr, TTemplatedAttribute):
                 known.update(attr.value_ref.i_indexes)
+        # Now re-remove those placeholders using the same config we used to
+        # make them.
         temp_placeholders = PlaceholderState(known=known, config=config)
         tag_ref = temp_placeholders.remove_placeholders(starttag_text)
+        if not temp_placeholders.is_empty:
+            raise AssertionError(
+                "There are extra placeholders still in the starttag_text."
+            )
+        # Now the last string should terminate the starttag and end with ">"
+        # So this length is the offset from the last interpolation to the start
+        # of the children's leading string.
         return len(tag_ref.strings[-1])
 
     def finalize_tag(
@@ -287,20 +299,25 @@ class TemplateParser(HTMLParser):
 
         We use this template as a "key" into the cache to get the TNode tree.
         """
-        # Only go looking for a template if there is an actual endtag.
         if start_i_index != endtag_i_index and endtag_i_index is not None:
-            # @NOTE: This is an assumption that no interpolations
-            # exist between the end tag interpolation itself and the
-            # "</", ie. "</{end_i}>".
+            # CASE: <{Comp}>...</{Comp}> or <{Comp}></{Comp}>
+
+            # Use the interpolation index of the callable in the closing tag
+            # preceding "string" index is always the same as an interpolation index
+            # The "string" should look like this: "...</"
             children_end_s_index = endtag_i_index
-            leading = template.strings[children_start_s_index]
-            leading = leading[offset_into_children_start_s:]
-            if (
-                children_start_s_index == children_end_s_index
-            ):  # Entire children template is a string.
+            # Offset past the trailing part of the component's start tag to get to
+            # where the first "string" of the children's template starts.
+            leading = template.strings[children_start_s_index][
+                offset_into_children_start_s:
+            ]
+            if children_start_s_index == children_end_s_index:
+                # CASE: Entire children template is a string, leading == trailing.
                 leading = leading[: leading.rfind("</")]
                 children_ref = TemplateRef(strings=(leading,), i_indexes=())
             else:
+                # CASE: Children template contains interpolations so the trailing
+                # "string" will not be the same as the leading "string".
                 trailing = template.strings[children_end_s_index]
                 trailing = trailing[: trailing.rfind("</")]
                 children_ref = TemplateRef(
@@ -316,6 +333,7 @@ class TemplateParser(HTMLParser):
                     ),
                 )
         else:
+            # CASE: <{Comp} /> -- no children template
             children_ref = TemplateRef(strings=("",), i_indexes=())
         return children_ref
 

--- a/tdom/parser_test.py
+++ b/tdom/parser_test.py
@@ -3,7 +3,8 @@ from string.templatelib import Interpolation, Template
 import pytest
 
 from .parser import TemplateParser
-from .placeholders import TemplateRef, make_placeholder_config
+from .placeholders import make_placeholder_config
+from .template_utils import TemplateRef
 from .tnodes import (
     TComment,
     TComponent,
@@ -404,6 +405,7 @@ def test_component_element_with_children():
     assert node == TComponent(
         start_i_index=0,
         end_i_index=1,
+        children_ref=TemplateRef(strings=("<div>Hello, World!</div>",), i_indexes=()),
     )
 
 

--- a/tdom/parser_test.py
+++ b/tdom/parser_test.py
@@ -404,7 +404,6 @@ def test_component_element_with_children():
     assert node == TComponent(
         start_i_index=0,
         end_i_index=1,
-        children=(TElement("div", children=(TText.literal("Hello, World!"),)),),
     )
 
 

--- a/tdom/parser_test.py
+++ b/tdom/parser_test.py
@@ -499,3 +499,106 @@ class TestIncompleteParsing:
     def test_placeholder_missing_from_dangling_quote(self):
         with pytest.raises(ValueError, match="Parser expects more data"):
             _ = TemplateParser.parse(t'<div a="{None}')
+
+
+class TestComponentExtractChildrenTemplate:
+    @pytest.fixture
+    def Component(self):
+        def Component(children: Template, **attrs: str) -> Template:
+            return t""
+
+        return Component
+
+    def test_extract_no_content(self, Component):
+        node = TemplateParser.parse(t"<{Component}></{Component}>")
+        assert node == TComponent(
+            start_i_index=0,
+            end_i_index=1,
+            children_ref=TemplateRef(strings=("",), i_indexes=()),
+        )
+
+    def test_extract_startend(self, Component):
+        node = TemplateParser.parse(t"<{Component} />")
+        assert node == TComponent(
+            start_i_index=0,
+            end_i_index=None,
+            children_ref=TemplateRef(strings=("",), i_indexes=()),
+        )
+
+    def test_extract(self, Component):
+        node = TemplateParser.parse(
+            t"<{Component}><div>Hello, World!</div></{Component}>"
+        )
+        assert node == TComponent(
+            start_i_index=0,
+            end_i_index=1,
+            children_ref=TemplateRef(
+                strings=("<div>Hello, World!</div>",), i_indexes=()
+            ),
+        )
+
+    def test_extract_with_attr_interpolation(self, Component):
+        # Unquoted ...
+        node = TemplateParser.parse(
+            t"<{Component} title={'Skip over this.'}><div>Hello, World!</div></{Component}>"
+        )
+        assert node == TComponent(
+            start_i_index=0,
+            end_i_index=2,
+            attrs=(TInterpolatedAttribute(name="title", value_i_index=1),),
+            children_ref=TemplateRef(
+                strings=("<div>Hello, World!</div>",), i_indexes=()
+            ),
+        )
+        # Quoted...
+        node2 = TemplateParser.parse(
+            t'<{Component} title="{"Skip over this."}"><div>Hello, World!</div></{Component}>'
+        )
+        assert node2 == node
+
+    def test_extract_with_literal_attr_gt_char(self, Component):
+        node = TemplateParser.parse(
+            t'<{Component} title="1 > 0"><div>Hello, World!</div></{Component}>'
+        )
+        assert node == TComponent(
+            start_i_index=0,
+            end_i_index=1,
+            attrs=(TLiteralAttribute("title", "1 > 0"),),
+            children_ref=TemplateRef(
+                strings=("<div>Hello, World!</div>",), i_indexes=()
+            ),
+        )
+
+    def test_extract_with_interpolated_attr_literal_attr_gt_char(self, Component):
+        node = TemplateParser.parse(
+            t'<{Component} id={"simple"} title="1 > 0"><div>Hello, World!</div></{Component}>'
+        )
+        assert node == TComponent(
+            start_i_index=0,
+            end_i_index=2,
+            attrs=(
+                TInterpolatedAttribute(name="id", value_i_index=1),
+                TLiteralAttribute("title", "1 > 0"),
+            ),
+            children_ref=TemplateRef(
+                strings=("<div>Hello, World!</div>",), i_indexes=()
+            ),
+        )
+
+    def test_extract_with_templated_attr_gt_char(self, Component):
+        node = TemplateParser.parse(
+            t'<{Component} id="{"header"}_{"container"}" title="1 > 0"><div>Hello, World!</div></{Component}>'
+        )
+        assert node == TComponent(
+            start_i_index=0,
+            end_i_index=3,
+            attrs=(
+                TTemplatedAttribute(
+                    "id", TemplateRef(strings=("", "_", ""), i_indexes=(1, 2))
+                ),
+                TLiteralAttribute("title", "1 > 0"),
+            ),
+            children_ref=TemplateRef(
+                strings=("<div>Hello, World!</div>",), i_indexes=()
+            ),
+        )

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -675,9 +675,14 @@ class TemplateProcessor(ITemplateProcessor):
                 return self._process_comment(template, last_ctx, ref)
             case TFragment(children):
                 return self._process_fragment(template, last_ctx, children)
-            case TComponent(start_i_index, end_i_index, attrs):
+            case TComponent(start_i_index, end_i_index, children_ref, attrs):
                 return self._process_component(
-                    template, last_ctx, attrs, start_i_index, end_i_index
+                    template,
+                    last_ctx,
+                    attrs,
+                    start_i_index,
+                    end_i_index,
+                    children_ref,
                 )
             case TElement(tag, attrs, children):
                 return self._process_element(template, last_ctx, tag, attrs, children)
@@ -799,33 +804,6 @@ class TemplateProcessor(ITemplateProcessor):
             return attrs_str
         return ""
 
-    def _extract_component_template(
-        self,
-        template: Template,
-        attrs: tuple[TAttribute, ...],
-        start_i_index: int,
-        end_i_index: int | None,
-        check_callables: bool = True,
-    ) -> Template:
-        body_start_s_index = (
-            start_i_index
-            + 1
-            + len([1 for attr in attrs if not isinstance(attr, TLiteralAttribute)])
-        )
-        if start_i_index != end_i_index and end_i_index is not None:
-            # @TODO: We should do this during parsing.
-            if (
-                check_callables
-                and template.interpolations[start_i_index].value
-                != template.interpolations[end_i_index].value
-            ):
-                raise TypeError(
-                    "Component callable in start tag must match component callable in end tag."
-                )
-            return extract_embedded_template(template, body_start_s_index, end_i_index)
-        else:
-            return t""
-
     def _process_component(
         self,
         template: Template,
@@ -833,13 +811,21 @@ class TemplateProcessor(ITemplateProcessor):
         attrs: tuple[TAttribute, ...],
         start_i_index: int,
         end_i_index: int | None,
+        children_ref: TemplateRef,
     ) -> str:
         """
         Invoke a component and process the result into a string.
         """
-        children_template = self._extract_component_template(
-            template, attrs, start_i_index, end_i_index, check_callables=True
-        )
+        children_template = children_ref.resolve(template.interpolations)
+        if (
+            start_i_index != end_i_index
+            and end_i_index is not None
+            and template.interpolations[start_i_index].value
+            != template.interpolations[end_i_index].value
+        ):
+            raise TypeError(
+                "Component callable in start tag must match component callable in end tag."
+            )
         component_callable = template.interpolations[start_i_index].value
         result_t = self.component_processor_api.process(
             template, last_ctx, component_callable, attrs, children_template
@@ -1013,47 +999,6 @@ def resolve_text_without_recursion(
                 if value_str:
                     text.append(value_str)
         return "".join(text)
-
-
-def extract_embedded_template(
-    template: Template, body_start_s_index: int, end_i_index: int
-) -> Template:
-    """
-    Extract the template parts exclusively from start tag to end tag.
-
-    Note that interpolations INSIDE the start tag make this more complex
-    than just "the `s_index` after the component callable's `i_index`".
-
-    Example:
-    ```python
-    template = (
-        t'<{comp} attr={attr}>'
-            t'<div>{content} <span>{footer}</span></div>'
-        t'</{comp}>'
-    )
-    assert extract_children_template(template, 2, 4) == (
-        t'<div>{content} <span>{footer}</span></div>'
-    )
-    starttag = t'<{comp} attr={attr}>'
-    endtag = t'</{comp}>'
-    assert template == starttag + extract_children_template(template, 2, 4) + endtag
-    ```
-    @DESIGN: "There must be a better way."
-    """
-    # Copy the parts out of the containing template.
-    index = body_start_s_index
-    last_s_index = end_i_index
-    parts = []
-    while index <= last_s_index:
-        parts.append(template.strings[index])
-        if index != last_s_index:
-            parts.append(template.interpolations[index])
-        index += 1
-    # Now trim the first part to the end of the opening tag.
-    parts[0] = parts[0][parts[0].find(">") + 1 :]
-    # Now trim the last part (could also be the first) to the start of the closing tag.
-    parts[-1] = parts[-1][: parts[-1].rfind("<")]
-    return Template(*parts)
 
 
 def _make_default_template_processor(

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -675,7 +675,7 @@ class TemplateProcessor(ITemplateProcessor):
                 return self._process_comment(template, last_ctx, ref)
             case TFragment(children):
                 return self._process_fragment(template, last_ctx, children)
-            case TComponent(start_i_index, end_i_index, attrs, children):
+            case TComponent(start_i_index, end_i_index, attrs):
                 return self._process_component(
                     template, last_ctx, attrs, start_i_index, end_i_index
                 )

--- a/tdom/tnodes.py
+++ b/tdom/tnodes.py
@@ -91,7 +91,6 @@ class TComponent(TNode):
     # TODO: hold on to _s_indexes too, when we start to need them.
 
     attrs: tuple[TAttribute, ...] = field(default_factory=tuple)
-    children: tuple[TNode, ...] = field(default_factory=tuple)
 
 
 type TTag = TElement | TComponent | TFragment

--- a/tdom/tnodes.py
+++ b/tdom/tnodes.py
@@ -88,7 +88,10 @@ class TComponent(TNode):
     end_i_index: int | None = None
     """The interpolation index for the component's ending tag name, if any."""
 
-    # TODO: hold on to _s_indexes too, when we start to need them.
+    children_ref: TemplateRef = field(
+        default_factory=lambda: TemplateRef(strings=("",), i_indexes=())
+    )
+    """The template ref that describes the component's children template."""
 
     attrs: tuple[TAttribute, ...] = field(default_factory=tuple)
 


### PR DESCRIPTION
Move component children template extraction to the parser.

- TemplateParser: Track the current strings index in addition to the already tracked current interpolations index.
- TemplateParser: Precompute a component's children template into a `TemplateRef` called `children_ref`.
    - Use current strings index and current interpolations index.
    - Use `get_starttag_text` from Python's HTML parser to get the original starttag text.
- TemplateProcessor: Each time we process a component move the current interpolations into `children_ref` to get a current `children` `Template` to pass during invocation.

Fixes #120 
Fixes #130
Punts on #134