### PR TITLE
children and provided attrs must be named

### DIFF
--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -403,8 +403,6 @@ def _prep_component_kwargs(
         attrs even if they are not specified in the component's `attrs` in
         the template. If an attribute with the same name is provided in
         `attrs` then it takes priority over entries in `provided_attrs`.
-        @NOTE: These will be injected into any component with `**kwargs`
-        in their signature unless provided already by `attrs`.
 
     `raise_on_requires_positional`:
         Optionally check and raise `TypeError` if the `callable_info` requires
@@ -434,14 +432,12 @@ def _prep_component_kwargs(
         if snake_name in callable_info.named_params or callable_info.kwargs:
             kwargs[snake_name] = attr_value
 
-    if "children" in callable_info.named_params or callable_info.kwargs:
+    if "children" in callable_info.named_params:
         kwargs["children"] = children
 
     # Add in provided attrs if they haven't been set already and are wanted.
     for pattr_name, pattr_value in provided_attrs:
-        if pattr_name not in kwargs and (
-            pattr_name in callable_info.named_params or callable_info.kwargs
-        ):
+        if pattr_name not in kwargs and pattr_name in callable_info.named_params:
             kwargs[pattr_name] = pattr_value
 
     # Check to make sure we've fully satisfied the callable's requirements

--- a/tdom/processor_extension_test.py
+++ b/tdom/processor_extension_test.py
@@ -101,3 +101,22 @@ class TestComponentProcessor:
             html(body_t, app_state=None)
             == '<body><div class="hdr theme-default"><h1>App</h1></div></body>'
         )
+
+    def test_injected_works_with_kwargs(self):
+        """Test that provided attr is not injected into kwargs."""
+
+        def Comp(**kwargs):
+            return t"<div {kwargs}></div>"
+
+        html = self._make_html()
+        assert (
+            html(t"<{Comp}/>", app_state=AppState(theme_class="theme-spring"))
+            == "<div></div>"
+        )
+        assert (
+            html(
+                t'<{Comp} title="{"ok"}"/>',
+                app_state=AppState(theme_class="theme-spring"),
+            )
+            == '<div title="ok"></div>'
+        )

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -1608,27 +1608,22 @@ class TestFunctionComponentKeywordArgs:
     def FunctionComponentKeywordArgs(first: str, **attrs: t.Any) -> Template:
         # Ensure type correctness of props at runtime for testing purposes
         assert isinstance(first, str)
-        assert "children" in attrs
-        children = attrs.pop("children")
+        if "children" in attrs:
+            raise ValueError("Children not expected in attrs.")
         new_attrs = {"data-first": first, **attrs}
-        return t"<div {new_attrs}>Component with kwargs: {children}</div>"
+        return t"<div {new_attrs}>No children in kwargs</div>"
 
-    def test_children_always_passed_via_kwargs(self):
+    def test_children_not_passed_via_kwargs(self):
         res = html(
             t'<{self.FunctionComponentKeywordArgs} first="value" extra="info">Child content</{self.FunctionComponentKeywordArgs}>'
         )
-        assert (
-            res
-            == '<div data-first="value" extra="info">Component with kwargs: Child content</div>'
-        )
+        assert res == '<div data-first="value" extra="info">No children in kwargs</div>'
 
-    def test_children_always_passed_via_kwargs_even_when_empty(self):
+    def test_children_not_passed_via_kwargs_even_when_empty(self):
         res = html(
             t'<{self.FunctionComponentKeywordArgs} first="value" extra="info" />'
         )
-        assert (
-            res == '<div data-first="value" extra="info">Component with kwargs: </div>'
-        )
+        assert res == '<div data-first="value" extra="info">No children in kwargs</div>'
 
 
 class TestComponentSpecialUsage:


### PR DESCRIPTION
Do not inject `children` or `provided_attrs` unless asked for.