### PR TITLE
Only allow components to self-close and correct simple "/>" ambiguity.

### DIFF
--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -387,22 +387,23 @@ class TemplateParser(HTMLParser):
     # ------------------------------------------
 
     def handle_starttag(self, tag: str, attrs: Sequence[HTMLAttribute]) -> None:
-        open_tag = self.make_open_tag(tag, attrs)
         # An unquoted attribute value within a self-closing tag can consume
         # the "/" as part of the attribute's value if not separated by whitespace.
         # This is the CORRECT behavior but can can be especially confusing if
         # preceded by an interpolation, such as `<{Comp} name={value}/>`.
-        # We explicitly dissallow this usage without preceding ascii whitespace.
+        # We correct this usage by removing the / from the last attr's value
+        # and treating the tag as self-closing.
         # This applies to all tags (components or not).
-        if self.always_get_starttag_text().endswith("/>"):
-            if isinstance(open_tag, OpenTComponent):
-                error_tag = self.get_source().format_starttag(open_tag.start_i_index)
-            else:
-                error_tag = tag
-            raise ValueError(
-                f'Ambiguous self-closing tag, "<{error_tag}.../>", please precede "/>" with whitespace or apply quotes around the last attribute value.'
+        if (
+            self.always_get_starttag_text().endswith("/>")
+            and len(attrs) > 0
+            and isinstance(attrs[-1][1], str)  # attr is not boolean
+            and attrs[-1][1][-1] == "/"  # attr value ends with /
+        ):
+            return self.handle_startendtag(
+                tag, (*attrs[:-1], (attrs[-1][0], attrs[-1][1][:-1]))
             )
-
+        open_tag = self.make_open_tag(tag, attrs)
         if isinstance(open_tag, OpenTElement) and open_tag.tag in VOID_ELEMENTS:
             final_tag = self.finalize_tag(open_tag)
             self.append_child(final_tag)

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -399,7 +399,9 @@ class TemplateParser(HTMLParser):
             and len(attrs) > 0
             and isinstance(attrs[-1][1], str)  # attr is not boolean
             and attrs[-1][1][-1] == "/"  # attr value ends with /
+            and not self.placeholders.copy().remove_placeholders(tag).is_literal
         ):
+            # Only correct self-closing for components.
             return self.handle_startendtag(
                 tag, (*attrs[:-1], (attrs[-1][0], attrs[-1][1][:-1]))
             )
@@ -412,6 +414,11 @@ class TemplateParser(HTMLParser):
 
     def handle_startendtag(self, tag: str, attrs: Sequence[HTMLAttribute]) -> None:
         """Dispatch a self-closing tag, `<tag />` to specialized handlers."""
+        if self.placeholders.copy().remove_placeholders(tag).is_literal:
+            # Don't self-close normal tags.
+            raise ValueError(
+                "Self-closing xhtml style tags are only supported for components."
+            )
         open_tag = self.make_open_tag(tag, attrs)
         final_tag = self.finalize_tag(open_tag)
         self.append_child(final_tag)

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -189,11 +189,9 @@ class TemplateParser(HTMLParser):
         # @NOTE: This must be called when the tag is handled since it is
         # populated based on the most recently finished start tag. Otherwise
         # the value will be out of sync.
-        starttag_text = self.get_starttag_text()
-        if starttag_text is None:
-            raise AssertionError(
-                f"Expected startag_text to be set when parsing component at {i_index}."
-            )
+        starttag_text = self.always_get_starttag_text(
+            f"Expected startag_text to be set when parsing component at {i_index}."
+        )
 
         tattrs = self.make_tattrs(attrs)
 
@@ -371,12 +369,40 @@ class TemplateParser(HTMLParser):
                 # any of this in the parser, instead relying on higher layers.
                 return tag_ref.i_indexes[0]
 
+    def always_get_starttag_text(
+        self, msg: str = "Expecting starttag text to be set."
+    ) -> str:
+        """
+        Wrap get_starttag_text and just raise if None is returned.
+
+        Do this so we don't guard for `None` everywhere.
+        """
+        starttag_text = self.get_starttag_text()
+        if starttag_text is None:
+            raise AssertionError(msg)
+        return starttag_text
+
     # ------------------------------------------
     # HTMLParser tag callbacks
     # ------------------------------------------
 
     def handle_starttag(self, tag: str, attrs: Sequence[HTMLAttribute]) -> None:
         open_tag = self.make_open_tag(tag, attrs)
+        # An unquoted attribute value within a self-closing tag can consume
+        # the "/" as part of the attribute's value if not separated by whitespace.
+        # This is the CORRECT behavior but can can be especially confusing if
+        # preceded by an interpolation, such as `<{Comp} name={value}/>`.
+        # We explicitly dissallow this usage without preceding ascii whitespace.
+        # This applies to all tags (components or not).
+        if self.always_get_starttag_text().endswith("/>"):
+            if isinstance(open_tag, OpenTComponent):
+                error_tag = self.get_source().format_starttag(open_tag.start_i_index)
+            else:
+                error_tag = tag
+            raise ValueError(
+                f'Ambiguous self-closing tag, "<{error_tag}.../>", please precede "/>" with whitespace or apply quotes around the last attribute value.'
+            )
+
         if isinstance(open_tag, OpenTElement) and open_tag.tag in VOID_ELEMENTS:
             final_tag = self.finalize_tag(open_tag)
             self.append_child(final_tag)

--- a/tdom/parser_test.py
+++ b/tdom/parser_test.py
@@ -624,6 +624,7 @@ class TestAmbiguousSelfCloseCheck:
             t"<{comp} {attrs}/>",  # Still ok because attr name cannot contain /
             t"<{comp} />",
             t"<{comp} title=literal />",
+            t"<{comp} title=literal/ ></{comp}>",  # This is really gross but shouldn't be common.
             t'<{comp} title="literal"/>',
             t"<{comp} title={dynamic} />",
             t'<{comp} title="{dynamic}"/>',
@@ -654,6 +655,7 @@ class TestAmbiguousSelfCloseCheck:
             t"<div {attrs}/>",  # Still ok because attr name cannot contain /
             t"<div />",
             t"<div title=literal />",
+            t"<div title=literal/ ></div>",  # This is really gross but shouldn't be common.
             t'<div title="literal"/>',
             t"<div title={dynamic} />",
             t'<div title="{dynamic}"/>',

--- a/tdom/parser_test.py
+++ b/tdom/parser_test.py
@@ -602,3 +602,75 @@ class TestComponentExtractChildrenTemplate:
                 strings=("<div>Hello, World!</div>",), i_indexes=()
             ),
         )
+
+
+class TestAmbiguousSelfCloseCheck:
+    @pytest.fixture
+    def comp(self):
+        def component(
+            active: bool = False, title: str = "Title", children: Template = t""
+        ) -> Template:
+            dataset = {"active": active}
+            return t"<div data={dataset} title={title}>{children}</div>"
+
+        return component
+
+    def test_component_ok(self, comp):
+        dynamic = "dynamic"
+        attrs = {"active": True}
+        for template in [
+            t"<{comp}/>",
+            t"<{comp} active/>",  # Still ok because attr name cannot contain /
+            t"<{comp} {attrs}/>",  # Still ok because attr name cannot contain /
+            t"<{comp} />",
+            t"<{comp} title=literal />",
+            t'<{comp} title="literal"/>',
+            t"<{comp} title={dynamic} />",
+            t'<{comp} title="{dynamic}"/>',
+            t"<{comp} title={dynamic}literal />",
+            t'<{comp} title="{dynamic}literal"/>',
+        ]:
+            tnode = TemplateParser.parse(template)
+            assert isinstance(tnode, TComponent) and tnode.start_i_index == 0
+
+    def test_component_ambiguous_error(self, comp):
+        dynamic = "dynamic"
+        for template in (
+            t"<{comp} title=literal/>",
+            t"<{comp} title={dynamic}/>",
+            t"<{comp} title={dynamic}literal/>",
+            t"<{comp} title=/>",
+            t"<{comp} title=     />",  # WS between = and value is ignored, so title=/
+        ):
+            with pytest.raises(ValueError, match="Ambiguous self-closing tag"):
+                _ = TemplateParser.parse(template)
+
+    def test_element_ok(self):
+        dynamic = "dynamic"
+        attrs = {"active": True}
+        for template in (
+            t"<div/>",
+            t"<div active/>",  # Still ok because attr name cannot contain /
+            t"<div {attrs}/>",  # Still ok because attr name cannot contain /
+            t"<div />",
+            t"<div title=literal />",
+            t'<div title="literal"/>',
+            t"<div title={dynamic} />",
+            t'<div title="{dynamic}"/>',
+            t"<div title={dynamic}literal />",
+            t'<div title="{dynamic}literal"/>',
+        ):
+            tnode = TemplateParser.parse(template)
+            assert isinstance(tnode, TElement) and tnode.tag == "div"
+
+    def test_element_ambiguous_error(self):
+        dynamic = "dynamic"
+        for template in (
+            t"<div title=literal/>",
+            t"<div title={dynamic}/>",
+            t"<div title={dynamic}literal/>",
+            t"<div title=/>",
+            t"<div title=     />",  # WS between = and value is ignored, so title=/
+        ):
+            with pytest.raises(ValueError, match="Ambiguous self-closing tag"):
+                _ = TemplateParser.parse(template)

--- a/tdom/parser_test.py
+++ b/tdom/parser_test.py
@@ -681,7 +681,7 @@ class TestAmbiguousSelfCloseCheck:
             == TemplateRef(strings=("prefix", ""), i_indexes=(1,))
         )
 
-    def test_element_ok(self):
+    def test_element_self_closing_error(self):
         dynamic = "dynamic"
         attrs = {"active": True}
         for template in (
@@ -690,32 +690,14 @@ class TestAmbiguousSelfCloseCheck:
             t"<div {attrs}/>abc",  # Still ok because attr name cannot contain /
             t"<div />abc",
             t"<div title=literal />abc",
-            t"<div title=literal/ ></div>abc",  # This is really gross but shouldn't be common.
             t'<div title="literal"/>abc',
             t"<div title={dynamic} />abc",
             t'<div title="{dynamic}"/>abc',
             t"<div title={dynamic}literal />abc",
             t'<div title="{dynamic}literal"/>abc',
         ):
-            tnode = TemplateParser.parse(template)
-            assert (
-                isinstance(tnode, TFragment)
-                and len(tnode.children) == 2
-                and isinstance(tnode.children[0], TElement)
-            )
-
-    def test_element_ambiguous_corrected(self):
-        dynamic = "dynamic"
-        for template in (
-            t"<div title=literal/>abc",
-            t"<div title={dynamic}/>abc",
-            t"<div title={dynamic}literal/>abc",
-            t"<div title=/>abc",
-            t"<div title=     />abc",  # WS between = and value is ignored, so title=/
-        ):
-            tnode = TemplateParser.parse(template)
-            assert (
-                isinstance(tnode, TFragment)
-                and len(tnode.children) == 2
-                and isinstance(tnode.children[0], TElement)
-            )
+            with pytest.raises(
+                ValueError,
+                match="Self-closing xhtml style tags are only supported for components.",
+            ):
+                _ = TemplateParser.parse(template)

--- a/tdom/parser_test.py
+++ b/tdom/parser_test.py
@@ -619,60 +619,103 @@ class TestAmbiguousSelfCloseCheck:
         dynamic = "dynamic"
         attrs = {"active": True}
         for template in [
-            t"<{comp}/>",
-            t"<{comp} active/>",  # Still ok because attr name cannot contain /
-            t"<{comp} {attrs}/>",  # Still ok because attr name cannot contain /
-            t"<{comp} />",
-            t"<{comp} title=literal />",
-            t"<{comp} title=literal/ ></{comp}>",  # This is really gross but shouldn't be common.
-            t'<{comp} title="literal"/>',
-            t"<{comp} title={dynamic} />",
-            t'<{comp} title="{dynamic}"/>',
-            t"<{comp} title={dynamic}literal />",
-            t'<{comp} title="{dynamic}literal"/>',
+            t"<{comp}/>abc",
+            t"<{comp} active/>abc",  # Still ok because attr name cannot contain /
+            t"<{comp} {attrs}/>abc",  # Still ok because attr name cannot contain /
+            t"<{comp} />abc",
+            t"<{comp} title=literal />abc",
+            t"<{comp} title=literal/ ></{comp}>abc",  # This is really gross but shouldn't be common.
+            t'<{comp} title="literal"/>abc',
+            t"<{comp} title={dynamic} />abc",
+            t'<{comp} title="{dynamic}"/>abc',
+            t"<{comp} title={dynamic}literal />abc",
+            t'<{comp} title="{dynamic}literal"/>abc',
         ]:
             tnode = TemplateParser.parse(template)
-            assert isinstance(tnode, TComponent) and tnode.start_i_index == 0
+            assert (
+                isinstance(tnode, TFragment)
+                and len(tnode.children) == 2
+                and isinstance(tnode.children[0], TComponent)
+            )
 
-    def test_component_ambiguous_error(self, comp):
+    def test_component_ambiguous_corrected(self, comp):
         dynamic = "dynamic"
         for template in (
-            t"<{comp} title=literal/>",
-            t"<{comp} title={dynamic}/>",
-            t"<{comp} title={dynamic}literal/>",
-            t"<{comp} title=/>",
-            t"<{comp} title=     />",  # WS between = and value is ignored, so title=/
+            t"<{comp} title=literal/>abc",
+            t"<{comp} title={dynamic}/>abc",
+            t"<{comp} title={dynamic}literal/>abc",
+            t"<{comp} title=/>abc",
+            t"<{comp} title=     />abc",  # WS between = and value is ignored, so title=/
         ):
-            with pytest.raises(ValueError, match="Ambiguous self-closing tag"):
-                _ = TemplateParser.parse(template)
+            tnode = TemplateParser.parse(template)
+            assert (
+                isinstance(tnode, TFragment)
+                and len(tnode.children) == 2
+                and isinstance(tnode.children[0], TComponent)
+            )
+
+    def test_component_ambiguous_corrected_attr_value_literal(self, comp):
+        tnode = TemplateParser.parse(t"<{comp} title=literal/>")
+        assert (
+            isinstance(tnode, TComponent)
+            and isinstance(tnode.attrs[-1], TLiteralAttribute)
+            and tnode.attrs[-1].value == "literal"
+        )
+
+    def test_component_ambiguous_corrected_attr_value_interpolated(self, comp):
+        dynamic = "dynamic"
+        tnode = TemplateParser.parse(t"<{comp} title={dynamic}/>")
+        assert (
+            isinstance(tnode, TComponent)
+            and isinstance(tnode.attrs[-1], TInterpolatedAttribute)
+            and tnode.attrs[-1].value_i_index == 1
+        )
+
+    def test_component_ambiguous_corrected_attr_value_templated(self, comp):
+        dynamic = "dynamic"
+        tnode = TemplateParser.parse(t"<{comp} title=prefix{dynamic}/>")
+        assert (
+            isinstance(tnode, TComponent)
+            and isinstance(tnode.attrs[-1], TTemplatedAttribute)
+            and tnode.attrs[-1].value_ref
+            == TemplateRef(strings=("prefix", ""), i_indexes=(1,))
+        )
 
     def test_element_ok(self):
         dynamic = "dynamic"
         attrs = {"active": True}
         for template in (
-            t"<div/>",
-            t"<div active/>",  # Still ok because attr name cannot contain /
-            t"<div {attrs}/>",  # Still ok because attr name cannot contain /
-            t"<div />",
-            t"<div title=literal />",
-            t"<div title=literal/ ></div>",  # This is really gross but shouldn't be common.
-            t'<div title="literal"/>',
-            t"<div title={dynamic} />",
-            t'<div title="{dynamic}"/>',
-            t"<div title={dynamic}literal />",
-            t'<div title="{dynamic}literal"/>',
+            t"<div/>abc",
+            t"<div active/>abc",  # Still ok because attr name cannot contain /
+            t"<div {attrs}/>abc",  # Still ok because attr name cannot contain /
+            t"<div />abc",
+            t"<div title=literal />abc",
+            t"<div title=literal/ ></div>abc",  # This is really gross but shouldn't be common.
+            t'<div title="literal"/>abc',
+            t"<div title={dynamic} />abc",
+            t'<div title="{dynamic}"/>abc',
+            t"<div title={dynamic}literal />abc",
+            t'<div title="{dynamic}literal"/>abc',
         ):
             tnode = TemplateParser.parse(template)
-            assert isinstance(tnode, TElement) and tnode.tag == "div"
+            assert (
+                isinstance(tnode, TFragment)
+                and len(tnode.children) == 2
+                and isinstance(tnode.children[0], TElement)
+            )
 
-    def test_element_ambiguous_error(self):
+    def test_element_ambiguous_corrected(self):
         dynamic = "dynamic"
         for template in (
-            t"<div title=literal/>",
-            t"<div title={dynamic}/>",
-            t"<div title={dynamic}literal/>",
-            t"<div title=/>",
-            t"<div title=     />",  # WS between = and value is ignored, so title=/
+            t"<div title=literal/>abc",
+            t"<div title={dynamic}/>abc",
+            t"<div title={dynamic}literal/>abc",
+            t"<div title=/>abc",
+            t"<div title=     />abc",  # WS between = and value is ignored, so title=/
         ):
-            with pytest.raises(ValueError, match="Ambiguous self-closing tag"):
-                _ = TemplateParser.parse(template)
+            tnode = TemplateParser.parse(template)
+            assert (
+                isinstance(tnode, TFragment)
+                and len(tnode.children) == 2
+                and isinstance(tnode.children[0], TElement)
+            )

--- a/tdom/placeholders.py
+++ b/tdom/placeholders.py
@@ -61,6 +61,9 @@ class PlaceholderState:
     config: PlaceholderConfig = field(default_factory=make_placeholder_config)
     """Collection of currently 'known and active' placeholder indexes."""
 
+    def copy(self):
+        return PlaceholderState(known=self.known.copy(), config=self.config)
+
     @property
     def is_empty(self) -> bool:
         return len(self.known) == 0


### PR DESCRIPTION
This is a 3rd option forward for #132  

I still need to research if there is a simpler way to deal with foreign elements like svg/mathml.