### PR TITLE
Improve error message for unclosed components whose attribute value might have consumed the slash.

### DIFF
--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -189,11 +189,9 @@ class TemplateParser(HTMLParser):
         # @NOTE: This must be called when the tag is handled since it is
         # populated based on the most recently finished start tag. Otherwise
         # the value will be out of sync.
-        starttag_text = self.get_starttag_text()
-        if starttag_text is None:
-            raise AssertionError(
-                f"Expected startag_text to be set when parsing component at {i_index}."
-            )
+        starttag_text = self.always_get_starttag_text(
+            f"Expected startag_text to be set when parsing component at {i_index}."
+        )
 
         tattrs = self.make_tattrs(attrs)
 
@@ -370,6 +368,19 @@ class TemplateParser(HTMLParser):
                 # component callable that matches the start tag. We do not check
                 # any of this in the parser, instead relying on higher layers.
                 return tag_ref.i_indexes[0]
+
+    def always_get_starttag_text(
+        self, msg: str = "Expecting starttag text to be set."
+    ) -> str:
+        """
+        Wrap get_starttag_text and just raise if None is returned.
+
+        Do this so we don't guard for `None` everywhere.
+        """
+        starttag_text = self.get_starttag_text()
+        if starttag_text is None:
+            raise AssertionError(msg)
+        return starttag_text
 
     # ------------------------------------------
     # HTMLParser tag callbacks

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -93,13 +93,6 @@ class SourceTracker:
                 f"Interpolation indices exceed bounds: {index1} {index2}: [0...{last_index}]"
             )
 
-    def expressions_match(self, i_index1: int, i_index2: int) -> bool:
-        self._check_indices(i_index1, i_index2)
-        return (
-            self.interpolations[i_index1].expression
-            == self.interpolations[i_index2].expression
-        )
-
     def values_match(self, i_index1: int, i_index2: int) -> bool:
         self._check_indices(i_index1, i_index2)
         return (

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -471,6 +471,33 @@ class TemplateParser(HTMLParser):
         self.placeholders = PlaceholderState()
         self.source = None
 
+    def has_ambiguous_forward_slash(self, open_tag: OpenTag) -> bool:
+        """
+        Detect when an unquoted attribute value consumes a trailing "/" that
+        *might* have been meant to attempt to self-close a tag, ie. "/>".
+
+        This can come up with literal values or values with interpolations.
+
+        Such as "<div title=test/>" or "<{Component} title=test/>".
+
+        Or more often "<{Component} title={title}/>" which should be corrected
+        with "<{Component} title={title} />".
+        """
+        if isinstance(open_tag, (OpenTElement, OpenTComponent)):
+            return (
+                # has attributes
+                len(open_tag.raw_attrs) > 0
+                # last attr not bare attribute
+                and open_tag.raw_attrs[-1][1] is not None
+                # last char of last attr is "/"
+                and open_tag.raw_attrs[-1][1][-1] == "/"
+                # parsed starttag ends with "/>"
+                and open_tag.starttag_text.endswith("/>")
+                # if parsed as startend then its not ambiguous
+                and not open_tag.startend
+            )
+        return False
+
     def close(self) -> None:
         if self.waiting_for_data():
             # We apply heuristics here to try to guess why the parser didn't finish.
@@ -483,7 +510,24 @@ class TemplateParser(HTMLParser):
                     "Parser expects more data, is the template valid html?"
                 )
         if self.stack:
-            raise ValueError("Invalid HTML structure: unclosed tags remain.")
+            e = ValueError("Invalid HTML structure: unclosed tags remain.")
+            # Check for tags that might have meant to self-close but whose
+            # unquoted last attribute value consumed a "/", ie. <div id=app/>.
+            parent = self.stack[-1]
+            if isinstance(parent, (OpenTElement, OpenTComponent)):
+                if isinstance(parent, OpenTElement):
+                    starttag = parent.tag
+                elif isinstance(parent, OpenTComponent):
+                    starttag = (
+                        f"{{{self.get_source().format_starttag(parent.start_i_index)}}}"
+                    )
+                if self.has_ambiguous_forward_slash(parent):
+                    e.add_note(
+                        f'Did you mean to quote the last attribute or put a space before "/>" for "<{starttag} .../>"?'
+                    )
+                else:
+                    e.add_note(f"Most recently unclosed tag is <{starttag} ...>")
+            raise e
         if not self.placeholders.is_empty:
             raise ValueError("Some placeholders were never resolved.")
         super().close()

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -26,8 +26,8 @@ type HTMLAttributesDict = dict[str, str | None]
 
 
 @dataclass(frozen=True)
-class ParseInfo:
-    "Track parse info for error reporting."
+class TagOpening:
+    "Track parse info at the opening of a tag for error reporting."
 
     starttag_text: str
     " Entire starttag as parsed, includes placeholders, . "
@@ -38,21 +38,37 @@ class ParseInfo:
 
 
 @dataclass(frozen=True)
-class OpenTElement:
-    parse_info: ParseInfo
+class TagClosing:
+    "Track info available when a tag is closed."
+
+    original_open_tag: OpenTag
+    " The original open tag that tracked this tag before it was closed. "
+
+
+class OpenTagBase:
+    """Mixin to make open tags hash by id and equal by id."""
+
+    def __hash__(self):
+        return hash(id(self))
+
+    def __eq__(self, other):
+        return id(self) == id(other)
+
+
+@dataclass(frozen=True, eq=False)
+class OpenTElement(OpenTagBase):
     tag: str
     attrs: tuple[TAttribute, ...]
     children: list[TNode] = field(default_factory=list)
 
 
-@dataclass(frozen=True)
-class OpenTFragment:
+@dataclass(frozen=True, eq=False)
+class OpenTFragment(OpenTagBase):
     children: list[TNode] = field(default_factory=list)
 
 
-@dataclass(frozen=True)
-class OpenTComponent:
-    parse_info: ParseInfo
+@dataclass(frozen=True, eq=False)
+class OpenTComponent(OpenTagBase):
     start_i_index: int
     children_start_s_index: int
     """The strings index where the component's children template starts."""
@@ -60,13 +76,17 @@ class OpenTComponent:
     """The offset INTO the starting string where the component's children template starts."""
     attrs: tuple[TAttribute, ...]
     # @NOTE: The `children` are discarded after parsing and are just used to
-    # track template consistency.  If the component is processed and
-    # returns its children template then that template will be
-    # re-parsed (or pulled from the cache).
+    # track template consistency or assist with error reporting.  If the
+    # component is processed and returns its children template then that
+    # template will be re-parsed (or pulled from the cache).
     children: list[TNode] = field(default_factory=list)
 
 
 type OpenTag = OpenTElement | OpenTFragment | OpenTComponent
+
+
+type TNodeContainer = TComponent | TElement | TFragment
+" Alias for union of tnodes that have children. "
 
 
 @dataclass
@@ -82,19 +102,41 @@ class SourceTracker:
     i_index: int = -1  # The current interpolation index.
     s_index: int = -1  # The current string index.
 
+    tag_closings: dict[TNodeContainer, TagClosing] = field(default_factory=dict)
+
+    tag_openings: dict[OpenTag, TagOpening] = field(default_factory=dict)
+
+    def record_tag_opening(
+        self,
+        open_tag: OpenTag,
+        starttag_text: str,
+        raw_attrs: Sequence[HTMLAttribute],
+        startend: bool,
+    ) -> TagOpening:
+        opening = self.tag_openings[open_tag] = TagOpening(
+            starttag_text=starttag_text, raw_attrs=raw_attrs, startend=startend
+        )
+        return opening
+
+    def record_tag_closing(
+        self, tnode: TNodeContainer, open_tag: OpenTag
+    ) -> TagClosing:
+        closing = self.tag_closings[tnode] = TagClosing(original_open_tag=open_tag)
+        return closing
+
+    def get_tag_closing(self, tnode: TNodeContainer) -> TagClosing:
+        """Get available info when `tnode` was created at closing of a tag."""
+        return self.tag_closings[tnode]
+
+    def get_tag_opening(self, open_tag: OpenTag) -> TagOpening:
+        """Get available info when `open_tag` was created at opening of a tag."""
+        return self.tag_openings[open_tag]
+
     @property
     def interpolations(self) -> tuple[Interpolation, ...]:
         return self.template.interpolations
 
-    def _check_indices(self, index1: int, index2: int):
-        last_index = len(self.interpolations) - 1
-        if max(index1, index2) > last_index or min(index1, index2) < 0:
-            raise ValueError(
-                f"Interpolation indices exceed bounds: {index1} {index2}: [0...{last_index}]"
-            )
-
     def values_match(self, i_index1: int, i_index2: int) -> bool:
-        self._check_indices(i_index1, i_index2)
         return (
             self.interpolations[i_index1].value == self.interpolations[i_index2].value
         )
@@ -131,7 +173,6 @@ class TemplateParser(HTMLParser):
     stack: list[OpenTag]
     placeholders: PlaceholderState
     source: SourceTracker | None
-    tmap: dict[TComponent | TElement | TFragment, OpenTag]
     " Map from completed tnodes back to their opentag for error reporting. "
 
     def __init__(self, *, convert_charrefs: bool = True):
@@ -195,18 +236,20 @@ class TemplateParser(HTMLParser):
         self, tag: str, attrs: Sequence[HTMLAttribute], startend: bool = False
     ) -> OpenTag:
         """Build an OpenTag from a raw tag and attribute tuples."""
+        source = self.get_source()
         tag_ref = self.placeholders.remove_placeholders(tag)
-
         if tag_ref.is_literal:
-            return OpenTElement(
-                parse_info=ParseInfo(
-                    starttag_text=self.get_starttag_text(),
-                    raw_attrs=attrs,
-                    startend=startend,
-                ),
+            open_tag = OpenTElement(
                 tag=tag,
                 attrs=self.make_tattrs(attrs),
             )
+            source.record_tag_opening(
+                open_tag,
+                starttag_text=self.get_starttag_text(),
+                raw_attrs=attrs,
+                startend=startend,
+            )
+            return open_tag
 
         if not tag_ref.is_singleton:
             raise ValueError(
@@ -244,15 +287,19 @@ class TemplateParser(HTMLParser):
             starttag_text=starttag_text,
         )
 
-        return OpenTComponent(
-            parse_info=ParseInfo(
-                starttag_text=starttag_text, raw_attrs=attrs, startend=startend
-            ),
+        open_tag = OpenTComponent(
             start_i_index=i_index,
             children_start_s_index=children_start_s_index,
             offset_into_children_start_s=offset_into_children_start_s,
             attrs=tattrs,
         )
+        source.record_tag_opening(
+            open_tag,
+            starttag_text=starttag_text,
+            raw_attrs=attrs,
+            startend=startend,
+        )
+        return open_tag
 
     def compute_offset_into_children_start_s(
         self,
@@ -304,15 +351,12 @@ class TemplateParser(HTMLParser):
         self, open_tag: OpenTag, endtag_i_index: int | None = None
     ) -> TNode:
         """Finalize an OpenTag into a TNode."""
+        source = self.get_source()
         match open_tag:
             case OpenTElement(tag=tag, attrs=attrs, children=children):
                 tnode = TElement(tag=tag, attrs=attrs, children=tuple(children))
-                self.tmap[tnode] = open_tag
-                return tnode
             case OpenTFragment(children=children):
                 tnode = TFragment(children=tuple(children))
-                self.tmap[tnode] = open_tag
-                return tnode
             case OpenTComponent(
                 start_i_index=start_i_index,
                 children_start_s_index=children_start_s_index,
@@ -324,7 +368,7 @@ class TemplateParser(HTMLParser):
                     endtag_i_index=endtag_i_index,
                     children_start_s_index=children_start_s_index,
                     offset_into_children_start_s=offset_into_children_start_s,
-                    template=self.get_source().template,
+                    template=source.template,
                 )
                 tnode = TComponent(
                     start_i_index=start_i_index,
@@ -332,8 +376,8 @@ class TemplateParser(HTMLParser):
                     children_ref=children_ref,
                     attrs=attrs,
                 )
-                self.tmap[tnode] = open_tag
-                return tnode
+        source.record_tag_closing(tnode, open_tag)
+        return tnode
 
     def extract_component_children_ref(
         self,
@@ -447,7 +491,8 @@ class TemplateParser(HTMLParser):
         with "<{Component} title={title} />".
         """
         if isinstance(open_tag, (OpenTElement, OpenTComponent)):
-            parse_info = open_tag.parse_info
+            source = self.get_source()
+            parse_info = source.get_tag_opening(open_tag)
             return (
                 # has attributes
                 len(parse_info.raw_attrs) > 0
@@ -491,8 +536,7 @@ class TemplateParser(HTMLParser):
                     "Component end tags must have exactly one interpolation."
                 )
             # Component tag endtag but no component tag is open...
-            source = self.get_source()
-            unmatched_endtag = source.format_endtag(tag_ref.i_indexes[0])
+            unmatched_endtag = self.get_source().format_endtag(tag_ref.i_indexes[0])
             raise ValueError(
                 f"Unexpected closing component tag </{{{unmatched_endtag}}}> with no open tag."
             )
@@ -501,7 +545,9 @@ class TemplateParser(HTMLParser):
         final_tag = self.finalize_tag(open_tag, endtag_i_index)
         self.append_child(final_tag)
 
-    def get_closed_tcomps(self, root: OpenTag | None) -> list[TComponent]:
+    def get_closed_tcomps(
+        self, root: OpenTag | None, recurse_component_children: bool = False
+    ) -> list[TComponent]:
         """
         Get TComponents that were closed during parsing starting from `root`.
 
@@ -520,6 +566,9 @@ class TemplateParser(HTMLParser):
             node = nodes.pop()
             if isinstance(node, TComponent):
                 tcomps.append(node)
+                if recurse_component_children:
+                    tag_closing = self.get_source().get_tag_closing(node)
+                    nodes.extend(tag_closing.original_open_tag.children)
             elif isinstance(node, (TElement, TFragment)):
                 nodes.extend(node.children)
         return tcomps
@@ -562,7 +611,6 @@ class TemplateParser(HTMLParser):
         self.stack = []
         self.placeholders = PlaceholderState()
         self.source = None
-        self.tmap = {}
 
     def close(self) -> None:
         if self.waiting_for_data():
@@ -591,9 +639,12 @@ class TemplateParser(HTMLParser):
                     f'Did you mean to quote the last attribute or put a space before "/>" for "<{{{starttag}}} .../>"?'
                 )
             else:
-                # CASE: "<{C2}><{C1} attr=/></{C2}>"
+                # CASE: t"<{C2}><{C1} attr=/></{C2}>"
                 # Maybe user meant to self-close <{C1} ...>, but closed by </{C2}> leaving <{C2}...> open?
-                for comp in reversed(self.get_closed_tcomps(parent)):
+                # CASE: t"<{C3}><{C2}><{C1} attr=/></{C2}></{C3}>"
+                for comp in reversed(
+                    self.get_closed_tcomps(parent, recurse_component_children=True)
+                ):
                     if (
                         comp.end_i_index is not None
                         and comp.start_i_index != comp.end_i_index
@@ -601,13 +652,15 @@ class TemplateParser(HTMLParser):
                             comp.start_i_index, comp.end_i_index
                         )
                     ):
-                        closed_tag = self.tmap[comp]
+                        tag_closing_info = source.get_tag_closing(comp)
                         starttag = source.format_starttag(comp.start_i_index)
                         endtag = source.format_endtag(comp.end_i_index)
                         e.add_note(
                             f"Component start tag, <{{{starttag}}}>, and end tag, </{{{endtag}}}>, have values that do not match."
                         )
-                        if self.has_ambiguous_forward_slash(closed_tag):
+                        if self.has_ambiguous_forward_slash(
+                            tag_closing_info.original_open_tag
+                        ):
                             e.add_note(
                                 f'Did you mean to quote the last attribute or put a space before "/>" for "<{{{starttag}}} .../>"?'
                             )

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -424,20 +424,6 @@ class TemplateParser(HTMLParser):
                     raise ValueError(
                         "Component end tags must have exactly one interpolation."
                     )
-                if not source.expressions_match(
-                    open_tag.start_i_index, tag_ref.i_indexes[0]
-                ) and not source.values_match(
-                    open_tag.start_i_index, tag_ref.i_indexes[0]
-                ):
-                    e = TypeError(
-                        "Component start and end tags must contain the same callable."
-                    )
-                    if self.has_ambiguous_forward_slash(open_tag):
-                        starttag = source.format_starttag(start_i_index)
-                        e.add_note(
-                            f'Did you mean to quote the last attribute or put a space before "/>" for "<{{{starttag}}} .../>"?'
-                        )
-                    raise e
                 return tag_ref.i_indexes[0]
 
     def get_starttag_text(self, msg: str = "Expecting starttag text to be set.") -> str:
@@ -498,12 +484,47 @@ class TemplateParser(HTMLParser):
 
     def handle_endtag(self, tag: str) -> None:
         if not self.stack:
-            raise ValueError(f"Unexpected closing tag </{tag}> with no open tag.")
-
+            tag_ref = self.placeholders.copy().remove_placeholders(tag)
+            if tag_ref.is_literal:
+                raise ValueError(f"Unexpected closing tag </{tag}> with no open tag.")
+            if not tag_ref.is_singleton:
+                # @TODO: Also it doesn't match anything
+                raise ValueError(
+                    "Component end tags must have exactly one interpolation."
+                )
+            # Component tag endtag but no component tag is open...
+            source = self.get_source()
+            unmatched_endtag = source.format_endtag(tag_ref.i_indexes[0])
+            raise ValueError(
+                f"Unexpected closing component tag </{{{unmatched_endtag}}}> with no open tag."
+            )
         open_tag = self.stack.pop()
         endtag_i_index = self.validate_end_tag(tag, open_tag)
         final_tag = self.finalize_tag(open_tag, endtag_i_index)
         self.append_child(final_tag)
+
+    def get_closed_tcomps(self, root: OpenTag | None) -> list[TComponent]:
+        """
+        Get TComponents that were closed during parsing starting from `root`.
+
+        If `root` is None then use the parser's default `root`.
+
+        TComponents should be returned in the order they were closed in:
+        from first closed to last closed.
+
+        @NOTE: That the root is an `OpenTag` but its `children` are actually `TNode`s.
+        """
+        if root is None:
+            root = self.root
+        tcomps = []
+        nodes = list(root.children)
+        while nodes:
+            node = nodes.pop()
+            if isinstance(node, TComponent):
+                tcomps.append(node)
+            elif isinstance(node, (TElement, TFragment)):
+                nodes.extend(node.children)
+        return tcomps
 
     # ------------------------------------------
     # HTMLParser other callbacks
@@ -557,20 +578,41 @@ class TemplateParser(HTMLParser):
                     "Parser expects more data, is the template valid html?"
                 )
         if self.stack:
+            source = self.get_source()
             e = ValueError("Invalid HTML structure: unclosed tags remain.")
-            # Check for tags that might have meant to self-close but whose
-            # unquoted last attribute value consumed a "/", ie. <div id=app/>.
+            # @TODO: We need to determine which tags this might apply to,
+            # this only applies to components.
             parent = self.stack[-1]
-            # @TODO: We need to determine which tags this might apply to, this only applies to components.
             if isinstance(parent, OpenTComponent) and self.has_ambiguous_forward_slash(
                 parent
             ):
-                starttag = (
-                    f"{{{self.get_source().format_starttag(parent.start_i_index)}}}"
-                )
+                # CASE: "<{C1} attr={value}/>" -- meant to self-close
+                # Maybe user meant to self-close?
+                starttag = source.format_starttag(parent.start_i_index)
                 e.add_note(
-                    f'Did you mean to quote the last attribute or put a space before "/>" for "<{starttag} .../>"?'
+                    f'Did you mean to quote the last attribute or put a space before "/>" for "<{{{starttag}}} .../>"?'
                 )
+            else:
+                # CASE: "<{C2}><{C1} attr=/></{C2}>"
+                # Maybe user meant to self-close <{C1} ...>, but closed by </{C2}> leaving <{C2}...> open?
+                for comp in reversed(self.get_closed_tcomps(parent)):
+                    if (
+                        comp.end_i_index is not None
+                        and comp.start_i_index != comp.end_i_index
+                        and not source.values_match(
+                            comp.start_i_index, comp.end_i_index
+                        )
+                    ):
+                        closed_tag = self.tmap[comp]
+                        starttag = source.format_starttag(comp.start_i_index)
+                        endtag = source.format_endtag(comp.end_i_index)
+                        e.add_note(
+                            f"Component start tag, <{{{starttag}}}>, and end tag, </{{{endtag}}}>, have values that do not match."
+                        )
+                        if self.has_ambiguous_forward_slash(closed_tag):
+                            e.add_note(
+                                f'Did you mean to quote the last attribute or put a space before "/>" for "<{{{starttag}}} .../>"?'
+                            )
             raise e
         if not self.placeholders.is_empty:
             raise ValueError("Some placeholders were never resolved.")

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -593,15 +593,18 @@ class TemplateParser(HTMLParser):
         ref = self.placeholders.remove_placeholders(data)
         parent = self.get_parent()
         if parent.children and isinstance(parent.children[-1], TText):
+            prior_text = parent.children[-1]
             parent.children[-1] = TText(
-                ref=combine_template_refs(parent.children[-1].ref, ref)
+                ref=combine_template_refs(prior_text.ref, ref),
+                # Keep starting position of the prior text
+                parser_pos=prior_text.parser_pos,
             )
         else:
-            self.append_child(TText(ref=ref))
+            self.append_child(TText(ref=ref, parser_pos=self.get_parser_pos()))
 
     def handle_comment(self, data: str) -> None:
         ref = self.placeholders.remove_placeholders(data)
-        comment = TComment(ref)
+        comment = TComment(ref, parser_pos=self.get_parser_pos())
         self.append_child(comment)
 
     def handle_decl(self, decl: str) -> None:
@@ -610,7 +613,7 @@ class TemplateParser(HTMLParser):
             raise ValueError("Interpolations are not allowed in declarations.")
         elif decl.upper().startswith("DOCTYPE "):
             doctype_content = decl[7:].strip()
-            doctype = TDocumentType(doctype_content)
+            doctype = TDocumentType(doctype_content, parser_pos=self.get_parser_pos())
             self.append_child(doctype)
         else:
             raise NotImplementedError(

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -405,6 +405,33 @@ class TemplateParser(HTMLParser):
             raise AssertionError(msg)
         return starttag_text
 
+    def has_ambiguous_forward_slash(self, open_tag: OpenTag) -> bool:
+        """
+        Detect when an unquoted attribute value consumes a trailing "/" that
+        *might* have been meant to attempt to self-close a tag, ie. "/>".
+
+        This can come up with literal values or values with interpolations.
+
+        Such as "<div title=test/>" or "<{Component} title=test/>".
+
+        Or more often "<{Component} title={title}/>" which should be corrected
+        with "<{Component} title={title} />".
+        """
+        if isinstance(open_tag, (OpenTElement, OpenTComponent)):
+            return (
+                # has attributes
+                len(open_tag.raw_attrs) > 0
+                # last attr not bare attribute
+                and open_tag.raw_attrs[-1][1] is not None
+                # last char of last attr is "/"
+                and open_tag.raw_attrs[-1][1][-1] == "/"
+                # parsed starttag ends with "/>"
+                and open_tag.starttag_text.endswith("/>")
+                # if parsed as startend then its not ambiguous
+                and not open_tag.startend
+            )
+        return False
+
     # ------------------------------------------
     # HTMLParser tag callbacks
     # ------------------------------------------
@@ -470,33 +497,6 @@ class TemplateParser(HTMLParser):
         self.stack = []
         self.placeholders = PlaceholderState()
         self.source = None
-
-    def has_ambiguous_forward_slash(self, open_tag: OpenTag) -> bool:
-        """
-        Detect when an unquoted attribute value consumes a trailing "/" that
-        *might* have been meant to attempt to self-close a tag, ie. "/>".
-
-        This can come up with literal values or values with interpolations.
-
-        Such as "<div title=test/>" or "<{Component} title=test/>".
-
-        Or more often "<{Component} title={title}/>" which should be corrected
-        with "<{Component} title={title} />".
-        """
-        if isinstance(open_tag, (OpenTElement, OpenTComponent)):
-            return (
-                # has attributes
-                len(open_tag.raw_attrs) > 0
-                # last attr not bare attribute
-                and open_tag.raw_attrs[-1][1] is not None
-                # last char of last attr is "/"
-                and open_tag.raw_attrs[-1][1][-1] == "/"
-                # parsed starttag ends with "/>"
-                and open_tag.starttag_text.endswith("/>")
-                # if parsed as startend then its not ambiguous
-                and not open_tag.startend
-            )
-        return False
 
     def close(self) -> None:
         if self.waiting_for_data():

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -25,7 +25,7 @@ type HTMLAttribute = tuple[str, str | None]
 type HTMLAttributesDict = dict[str, str | None]
 
 
-@dataclass
+@dataclass(frozen=True)
 class OpenTElement:
     starttag_text: str
     " Entire starttag as parsed, includes placeholders, used for debugging. "
@@ -38,12 +38,12 @@ class OpenTElement:
     children: list[TNode] = field(default_factory=list)
 
 
-@dataclass
+@dataclass(frozen=True)
 class OpenTFragment:
     children: list[TNode] = field(default_factory=list)
 
 
-@dataclass
+@dataclass(frozen=True)
 class OpenTComponent:
     starttag_text: str
     " Entire starttag as parsed, includes placeholders, used for debugging. "
@@ -127,12 +127,17 @@ class SourceTracker:
         """Format a component start tag for error messages."""
         return self.get_expression(i_index, fallback_prefix="component-starttag")
 
+    def format_endtag(self, i_index: int) -> str:
+        return self.get_expression(i_index, fallback_prefix="component-endtag")
+
 
 class TemplateParser(HTMLParser):
     root: OpenTFragment
     stack: list[OpenTag]
     placeholders: PlaceholderState
     source: SourceTracker | None
+    tmap: dict[TComponent | TElement | TFragment, OpenTag]
+    " Map from completed tnodes back to their opentag for error reporting. "
 
     def __init__(self, *, convert_charrefs: bool = True):
         # This calls HTMLParser.reset() which we override to set up our state.
@@ -304,9 +309,13 @@ class TemplateParser(HTMLParser):
         """Finalize an OpenTag into a TNode."""
         match open_tag:
             case OpenTElement(tag=tag, attrs=attrs, children=children):
-                return TElement(tag=tag, attrs=attrs, children=tuple(children))
+                tnode = TElement(tag=tag, attrs=attrs, children=tuple(children))
+                self.tmap[tnode] = open_tag
+                return tnode
             case OpenTFragment(children=children):
-                return TFragment(children=tuple(children))
+                tnode = TFragment(children=tuple(children))
+                self.tmap[tnode] = open_tag
+                return tnode
             case OpenTComponent(
                 start_i_index=start_i_index,
                 children_start_s_index=children_start_s_index,
@@ -320,12 +329,14 @@ class TemplateParser(HTMLParser):
                     offset_into_children_start_s=offset_into_children_start_s,
                     template=self.get_source().template,
                 )
-                return TComponent(
+                tnode = TComponent(
                     start_i_index=start_i_index,
                     end_i_index=endtag_i_index,
                     children_ref=children_ref,
                     attrs=attrs,
                 )
+                self.tmap[tnode] = open_tag
+                return tnode
 
     def extract_component_children_ref(
         self,
@@ -532,6 +543,7 @@ class TemplateParser(HTMLParser):
         self.stack = []
         self.placeholders = PlaceholderState()
         self.source = None
+        self.tmap = {}
 
     def close(self) -> None:
         if self.waiting_for_data():

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -27,6 +27,12 @@ type HTMLAttributesDict = dict[str, str | None]
 
 @dataclass
 class OpenTElement:
+    starttag_text: str
+    " Entire starttag as parsed, includes placeholders, used for debugging. "
+    raw_attrs: Sequence[HTMLAttribute]
+    " Attrs as parsed, includes placeholders, used for debugging. "
+    startend: bool
+    " Was parsed as startend tag, ie. <tag />, used for debugging. "
     tag: str
     attrs: tuple[TAttribute, ...]
     children: list[TNode] = field(default_factory=list)
@@ -39,6 +45,12 @@ class OpenTFragment:
 
 @dataclass
 class OpenTComponent:
+    starttag_text: str
+    " Entire starttag as parsed, includes placeholders, used for debugging. "
+    raw_attrs: Sequence[HTMLAttribute]
+    " Attrs as parsed, includes placeholders, used for debugging. "
+    startend: bool
+    " Was parsed as startend tag, ie. <tag />, used for debugging. "
     start_i_index: int
     children_start_s_index: int
     """The strings index where the component's children template starts."""
@@ -159,12 +171,20 @@ class TemplateParser(HTMLParser):
     # Tag Helpers
     # ------------------------------------------
 
-    def make_open_tag(self, tag: str, attrs: Sequence[HTMLAttribute]) -> OpenTag:
+    def make_open_tag(
+        self, tag: str, attrs: Sequence[HTMLAttribute], startend: bool = False
+    ) -> OpenTag:
         """Build an OpenTag from a raw tag and attribute tuples."""
         tag_ref = self.placeholders.remove_placeholders(tag)
 
         if tag_ref.is_literal:
-            return OpenTElement(tag=tag, attrs=self.make_tattrs(attrs))
+            return OpenTElement(
+                starttag_text=self.always_get_starttag_text(),
+                raw_attrs=attrs,
+                startend=startend,
+                tag=tag,
+                attrs=self.make_tattrs(attrs),
+            )
 
         if not tag_ref.is_singleton:
             raise ValueError(
@@ -203,6 +223,9 @@ class TemplateParser(HTMLParser):
         )
 
         return OpenTComponent(
+            starttag_text=starttag_text,
+            raw_attrs=attrs,
+            startend=startend,
             start_i_index=i_index,
             children_start_s_index=children_start_s_index,
             offset_into_children_start_s=offset_into_children_start_s,
@@ -396,7 +419,7 @@ class TemplateParser(HTMLParser):
 
     def handle_startendtag(self, tag: str, attrs: Sequence[HTMLAttribute]) -> None:
         """Dispatch a self-closing tag, `<tag />` to specialized handlers."""
-        open_tag = self.make_open_tag(tag, attrs)
+        open_tag = self.make_open_tag(tag, attrs, startend=True)
         final_tag = self.finalize_tag(open_tag)
         self.append_child(final_tag)
 

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -199,7 +199,7 @@ class TemplateParser(HTMLParser):
 
         if tag_ref.is_literal:
             return OpenTElement(
-                starttag_text=self.always_get_starttag_text(),
+                starttag_text=self.get_starttag_text(),
                 raw_attrs=attrs,
                 startend=startend,
                 tag=tag,
@@ -229,7 +229,7 @@ class TemplateParser(HTMLParser):
         # @NOTE: This must be called when the tag is handled since it is
         # populated based on the most recently finished start tag. Otherwise
         # the value will be out of sync.
-        starttag_text = self.always_get_starttag_text(
+        starttag_text = self.get_starttag_text(
             f"Expected startag_text to be set when parsing component at {i_index}."
         )
 
@@ -429,15 +429,13 @@ class TemplateParser(HTMLParser):
                     raise e
                 return tag_ref.i_indexes[0]
 
-    def always_get_starttag_text(
-        self, msg: str = "Expecting starttag text to be set."
-    ) -> str:
+    def get_starttag_text(self, msg: str = "Expecting starttag text to be set.") -> str:
         """
         Wrap get_starttag_text and just raise if None is returned.
 
         Do this so we don't guard for `None` everywhere.
         """
-        starttag_text = self.get_starttag_text()
+        starttag_text = super().get_starttag_text()
         if starttag_text is None:
             raise AssertionError(msg)
         return starttag_text

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -84,6 +84,26 @@ class SourceTracker:
     def interpolations(self) -> tuple[Interpolation, ...]:
         return self.template.interpolations
 
+    def _check_indices(self, index1: int, index2: int):
+        last_index = len(self.interpolations) - 1
+        if max(index1, index2) > last_index or min(index1, index2) < 0:
+            raise ValueError(
+                f"Interpolation indices exceed bounds: {index1} {index2}: [0...{last_index}]"
+            )
+
+    def expressions_match(self, i_index1: int, i_index2: int) -> bool:
+        self._check_indices(i_index1, i_index2)
+        return (
+            self.interpolations[i_index1].expression
+            == self.interpolations[i_index2].expression
+        )
+
+    def values_match(self, i_index1: int, i_index2: int) -> bool:
+        self._check_indices(i_index1, i_index2)
+        return (
+            self.interpolations[i_index1].value == self.interpolations[i_index2].value
+        )
+
     def advance_interpolation(self) -> int:
         """Call before processing an interpolation to move to the next one."""
         self.i_index += 1
@@ -360,7 +380,7 @@ class TemplateParser(HTMLParser):
 
     def validate_end_tag(self, tag: str, open_tag: OpenTag) -> int | None:
         """Validate that closing tag matches open tag. Return component end index if applicable."""
-        assert self.source, "Parser source tracker not initialized."
+        source = self.get_source()
         tag_ref = self.placeholders.remove_placeholders(tag)
 
         match open_tag:
@@ -380,16 +400,33 @@ class TemplateParser(HTMLParser):
 
             case OpenTComponent(start_i_index=start_i_index):
                 if tag_ref.is_literal:
-                    raise ValueError(
-                        f"Mismatched closing tag </{tag}> for component starting at {self.source.format_starttag(start_i_index)}."
+                    starttag = source.format_starttag(start_i_index)
+                    e = ValueError(
+                        f"Mismatched closing tag </{tag}> for component with tag {{{starttag}}}."
                     )
+                    if self.has_ambiguous_forward_slash(open_tag):
+                        e.add_note(
+                            f'Did you mean to quote the last attribute or put a space before "/>" for "<{{{starttag}}} .../>"?'
+                        )
+                    raise e
                 if not tag_ref.is_singleton:
                     raise ValueError(
                         "Component end tags must have exactly one interpolation."
                     )
-                # HERE BE DRAGONS: the interpolation at end_i_index shuld be a
-                # component callable that matches the start tag. We do not check
-                # any of this in the parser, instead relying on higher layers.
+                if not source.expressions_match(
+                    open_tag.start_i_index, tag_ref.i_indexes[0]
+                ) and not source.values_match(
+                    open_tag.start_i_index, tag_ref.i_indexes[0]
+                ):
+                    e = TypeError(
+                        "Component start and end tags must contain the same callable."
+                    )
+                    if self.has_ambiguous_forward_slash(open_tag):
+                        starttag = source.format_starttag(start_i_index)
+                        e.add_note(
+                            f'Did you mean to quote the last attribute or put a space before "/>" for "<{{{starttag}}} .../>"?'
+                        )
+                    raise e
                 return tag_ref.i_indexes[0]
 
     def always_get_starttag_text(

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -35,6 +35,7 @@ class OpenTagSourceInfo:
     @NOTE: These properties DEPEND on the placeholder configuration because
     they can contain embedded placeholders.
     """
+
     starttag_text: str
     " Entire starttag as parsed, includes placeholders, . "
     raw_attrs: tuple[HTMLAttribute, ...]
@@ -50,7 +51,8 @@ class OpenTagSourceInfo:
             raw_attrs=self.raw_attrs,
             startend=self.startend,
             starttag_pos=self.starttag_pos,
-            endtag_pos=endtag_pos)
+            endtag_pos=endtag_pos,
+        )
 
 
 @dataclass
@@ -147,7 +149,6 @@ class TemplateParser(HTMLParser):
     "List of children for each finished tcomponent, stored at closing. "
     sinfo_table: dict[FrozenPosition, TagSourceInfo]
     " Tags with more source info than just a position are tracked in this mapping. "
-
 
     def __init__(self, *, convert_charrefs: bool = True):
         # This calls HTMLParser.reset() which we override to set up our state.
@@ -285,8 +286,9 @@ class TemplateParser(HTMLParser):
                 starttag_text=starttag_text,
                 raw_attrs=tuple(attrs),
                 startend=startend,
-                starttag_pos=parser_pos
-            ))
+                starttag_pos=parser_pos,
+            ),
+        )
         return open_tag
 
     def compute_offset_into_children_start_s(
@@ -336,7 +338,10 @@ class TemplateParser(HTMLParser):
         return len(tag_ref.strings[-1])
 
     def finalize_tag(
-        self, open_tag: OpenTag, endtag_i_index: int | None = None, endtag_pos: FrozenPosition | None = None
+        self,
+        open_tag: OpenTag,
+        endtag_i_index: int | None = None,
+        endtag_pos: FrozenPosition | None = None,
     ) -> TNode:
         """Finalize an OpenTag into a TNode."""
         source = self.get_source()
@@ -346,9 +351,14 @@ class TemplateParser(HTMLParser):
                 attrs=attrs,
                 children=children,
                 parser_pos=parser_pos,
-                sinfo=sinfo
+                sinfo=sinfo,
             ):
-                tnode = TElement(tag=tag, attrs=attrs, children=tuple(children), parser_pos=parser_pos)
+                tnode = TElement(
+                    tag=tag,
+                    attrs=attrs,
+                    children=tuple(children),
+                    parser_pos=parser_pos,
+                )
                 self.sinfo_table[parser_pos] = sinfo.close(endtag_pos=endtag_pos)
             case OpenTFragment(children=children, parser_pos=parser_pos):
                 tnode = TFragment(children=tuple(children), parser_pos=parser_pos)
@@ -373,7 +383,7 @@ class TemplateParser(HTMLParser):
                     end_i_index=endtag_i_index,
                     children_ref=children_ref,
                     attrs=attrs,
-                    parser_pos=parser_pos
+                    parser_pos=parser_pos,
                 )
                 self.sinfo_table[parser_pos] = sinfo.close(endtag_pos=endtag_pos)
                 self.tcomponent_children[tnode] = children
@@ -478,7 +488,9 @@ class TemplateParser(HTMLParser):
             raise AssertionError(msg)
         return starttag_text
 
-    def has_ambiguous_forward_slash(self, sinfo: OpenTagSourceInfo | TagSourceInfo | None) -> bool:
+    def has_ambiguous_forward_slash(
+        self, sinfo: OpenTagSourceInfo | TagSourceInfo | None
+    ) -> bool:
         """
         Detect when an unquoted attribute value consumes a trailing "/" that
         *might* have been meant to attempt to self-close a tag, ie. "/>".
@@ -541,7 +553,8 @@ class TemplateParser(HTMLParser):
         open_tag = self.stack.pop()
         endtag_i_index = self.validate_end_tag(tag, open_tag)
         final_tag = self.finalize_tag(
-            open_tag, endtag_i_index=endtag_i_index, endtag_pos=self.get_parser_pos())
+            open_tag, endtag_i_index=endtag_i_index, endtag_pos=self.get_parser_pos()
+        )
         self.append_child(final_tag)
 
     def get_closed_tcomps(
@@ -653,15 +666,17 @@ class TemplateParser(HTMLParser):
                             comp.start_i_index, comp.end_i_index
                         )
                     ):
-                        sinfo = self.sinfo_table.get(comp.parser_pos) if comp.parser_pos is not None else None
+                        sinfo = (
+                            self.sinfo_table.get(comp.parser_pos)
+                            if comp.parser_pos is not None
+                            else None
+                        )
                         starttag = source.format_starttag(comp.start_i_index)
                         endtag = source.format_endtag(comp.end_i_index)
                         e.add_note(
                             f"Component start tag, <{{{starttag}}}>, and end tag, </{{{endtag}}}>, have values that do not match."
                         )
-                        if self.has_ambiguous_forward_slash(
-                            sinfo
-                        ):
+                        if self.has_ambiguous_forward_slash(sinfo):
                             e.add_note(
                                 f'Did you mean to quote the last attribute or put a space before "/>" for "<{{{starttag}}} .../>"?'
                             )

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -26,13 +26,20 @@ type HTMLAttributesDict = dict[str, str | None]
 
 
 @dataclass(frozen=True)
-class OpenTElement:
+class ParseInfo:
+    "Track parse info for error reporting."
+
     starttag_text: str
-    " Entire starttag as parsed, includes placeholders, used for debugging. "
+    " Entire starttag as parsed, includes placeholders, . "
     raw_attrs: Sequence[HTMLAttribute]
-    " Attrs as parsed, includes placeholders, used for debugging. "
+    " Attrs as parsed, includes placeholders. "
     startend: bool
-    " Was parsed as startend tag, ie. <tag />, used for debugging. "
+    " Was parsed as startend tag, ie. <tag />. "
+
+
+@dataclass(frozen=True)
+class OpenTElement:
+    parse_info: ParseInfo
     tag: str
     attrs: tuple[TAttribute, ...]
     children: list[TNode] = field(default_factory=list)
@@ -45,12 +52,7 @@ class OpenTFragment:
 
 @dataclass(frozen=True)
 class OpenTComponent:
-    starttag_text: str
-    " Entire starttag as parsed, includes placeholders, used for debugging. "
-    raw_attrs: Sequence[HTMLAttribute]
-    " Attrs as parsed, includes placeholders, used for debugging. "
-    startend: bool
-    " Was parsed as startend tag, ie. <tag />, used for debugging. "
+    parse_info: ParseInfo
     start_i_index: int
     children_start_s_index: int
     """The strings index where the component's children template starts."""
@@ -204,9 +206,11 @@ class TemplateParser(HTMLParser):
 
         if tag_ref.is_literal:
             return OpenTElement(
-                starttag_text=self.get_starttag_text(),
-                raw_attrs=attrs,
-                startend=startend,
+                parse_info=ParseInfo(
+                    starttag_text=self.get_starttag_text(),
+                    raw_attrs=attrs,
+                    startend=startend,
+                ),
                 tag=tag,
                 attrs=self.make_tattrs(attrs),
             )
@@ -248,9 +252,9 @@ class TemplateParser(HTMLParser):
         )
 
         return OpenTComponent(
-            starttag_text=starttag_text,
-            raw_attrs=attrs,
-            startend=startend,
+            parse_info=ParseInfo(
+                starttag_text=starttag_text, raw_attrs=attrs, startend=startend
+            ),
             start_i_index=i_index,
             children_start_s_index=children_start_s_index,
             offset_into_children_start_s=offset_into_children_start_s,
@@ -450,17 +454,18 @@ class TemplateParser(HTMLParser):
         with "<{Component} title={title} />".
         """
         if isinstance(open_tag, (OpenTElement, OpenTComponent)):
+            parse_info = open_tag.parse_info
             return (
                 # has attributes
-                len(open_tag.raw_attrs) > 0
+                len(parse_info.raw_attrs) > 0
                 # last attr not bare attribute
-                and open_tag.raw_attrs[-1][1] is not None
+                and parse_info.raw_attrs[-1][1] is not None
                 # last char of last attr is "/"
-                and open_tag.raw_attrs[-1][1][-1] == "/"
+                and parse_info.raw_attrs[-1][1][-1] == "/"
                 # parsed starttag ends with "/>"
-                and open_tag.starttag_text.endswith("/>")
+                and parse_info.starttag_text.endswith("/>")
                 # if parsed as startend then its not ambiguous
-                and not open_tag.startend
+                and not parse_info.startend
             )
         return False
 

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -515,12 +515,12 @@ class TemplateParser(HTMLParser):
             # unquoted last attribute value consumed a "/", ie. <div id=app/>.
             parent = self.stack[-1]
             if isinstance(parent, (OpenTElement, OpenTComponent)):
-                if isinstance(parent, OpenTElement):
-                    starttag = parent.tag
-                elif isinstance(parent, OpenTComponent):
+                if isinstance(parent, OpenTComponent):
                     starttag = (
                         f"{{{self.get_source().format_starttag(parent.start_i_index)}}}"
                     )
+                else:
+                    starttag = parent.tag
                 if self.has_ambiguous_forward_slash(parent):
                     e.add_note(
                         f'Did you mean to quote the last attribute or put a space before "/>" for "<{starttag} .../>"?'

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -4,7 +4,12 @@ from html.parser import HTMLParser
 from string.templatelib import Interpolation, Template
 
 from .htmlspec import VOID_ELEMENTS
+from .parser_utils import HTMLAttribute
 from .placeholders import PlaceholderConfig, PlaceholderState
+from .source import (
+    FrozenPosition,
+    TagSourceInfo,
+)
 from .template_utils import TemplateRef, combine_template_refs
 from .tnodes import (
     TAttribute,
@@ -21,60 +26,58 @@ from .tnodes import (
     TText,
 )
 
-type HTMLAttribute = tuple[str, str | None]
-type HTMLAttributesDict = dict[str, str | None]
 
+@dataclass(frozen=True, slots=True)
+class OpenTagSourceInfo:
+    """
+    Retained tag information from the parsed source.
 
-@dataclass(frozen=True)
-class TagOpening:
-    "Track parse info at the opening of a tag for error reporting."
-
+    @NOTE: These properties DEPEND on the placeholder configuration because
+    they can contain embedded placeholders.
+    """
     starttag_text: str
     " Entire starttag as parsed, includes placeholders, . "
-    raw_attrs: Sequence[HTMLAttribute]
+    raw_attrs: tuple[HTMLAttribute, ...]
     " Attrs as parsed, includes placeholders. "
     startend: bool
     " Was parsed as startend tag, ie. <tag />. "
+    starttag_pos: FrozenPosition
+    " Position of the parser when the element starttag was parsed. "
+
+    def close(self, endtag_pos: FrozenPosition | None = None) -> TagSourceInfo:
+        return TagSourceInfo(
+            starttag_text=self.starttag_text,
+            raw_attrs=self.raw_attrs,
+            startend=self.startend,
+            starttag_pos=self.starttag_pos,
+            endtag_pos=endtag_pos)
 
 
-@dataclass(frozen=True)
-class TagClosing:
-    "Track info available when a tag is closed."
-
-    original_open_tag: OpenTag
-    " The original open tag that tracked this tag before it was closed. "
-
-
-class OpenTagBase:
-    """Mixin to make open tags hash by id and equal by id."""
-
-    def __hash__(self):
-        return hash(id(self))
-
-    def __eq__(self, other):
-        return id(self) == id(other)
-
-
-@dataclass(frozen=True, eq=False)
-class OpenTElement(OpenTagBase):
+@dataclass
+class OpenTElement:
     tag: str
     attrs: tuple[TAttribute, ...]
+    parser_pos: FrozenPosition
+    sinfo: OpenTagSourceInfo
     children: list[TNode] = field(default_factory=list)
 
 
-@dataclass(frozen=True, eq=False)
-class OpenTFragment(OpenTagBase):
+@dataclass
+class OpenTFragment:
+    parser_pos: FrozenPosition | None = None
     children: list[TNode] = field(default_factory=list)
 
 
-@dataclass(frozen=True, eq=False)
-class OpenTComponent(OpenTagBase):
+@dataclass
+class OpenTComponent:
     start_i_index: int
     children_start_s_index: int
     """The strings index where the component's children template starts."""
     offset_into_children_start_s: int
     """The offset INTO the starting string where the component's children template starts."""
     attrs: tuple[TAttribute, ...]
+    parser_pos: FrozenPosition
+    sinfo: OpenTagSourceInfo
     # @NOTE: The `children` are discarded after parsing and are just used to
     # track template consistency or assist with error reporting.  If the
     # component is processed and returns its children template then that
@@ -83,10 +86,6 @@ class OpenTComponent(OpenTagBase):
 
 
 type OpenTag = OpenTElement | OpenTFragment | OpenTComponent
-
-
-type TNodeContainer = TComponent | TElement | TFragment
-" Alias for union of tnodes that have children. "
 
 
 @dataclass
@@ -101,36 +100,6 @@ class SourceTracker:
     # otherwise, when i_index < s_index, feeding a string.
     i_index: int = -1  # The current interpolation index.
     s_index: int = -1  # The current string index.
-
-    tag_closings: dict[TNodeContainer, TagClosing] = field(default_factory=dict)
-
-    tag_openings: dict[OpenTag, TagOpening] = field(default_factory=dict)
-
-    def record_tag_opening(
-        self,
-        open_tag: OpenTag,
-        starttag_text: str,
-        raw_attrs: Sequence[HTMLAttribute],
-        startend: bool,
-    ) -> TagOpening:
-        opening = self.tag_openings[open_tag] = TagOpening(
-            starttag_text=starttag_text, raw_attrs=raw_attrs, startend=startend
-        )
-        return opening
-
-    def record_tag_closing(
-        self, tnode: TNodeContainer, open_tag: OpenTag
-    ) -> TagClosing:
-        closing = self.tag_closings[tnode] = TagClosing(original_open_tag=open_tag)
-        return closing
-
-    def get_tag_closing(self, tnode: TNodeContainer) -> TagClosing:
-        """Get available info when `tnode` was created at closing of a tag."""
-        return self.tag_closings[tnode]
-
-    def get_tag_opening(self, open_tag: OpenTag) -> TagOpening:
-        """Get available info when `open_tag` was created at opening of a tag."""
-        return self.tag_openings[open_tag]
 
     @property
     def interpolations(self) -> tuple[Interpolation, ...]:
@@ -174,6 +143,11 @@ class TemplateParser(HTMLParser):
     placeholders: PlaceholderState
     source: SourceTracker | None
     " Map from completed tnodes back to their opentag for error reporting. "
+    tcomponent_children: dict[TComponent, list[TNode]]
+    "List of children for each finished tcomponent, stored at closing. "
+    sinfo_table: dict[FrozenPosition, TagSourceInfo]
+    " Tags with more source info than just a position are tracked in this mapping. "
+
 
     def __init__(self, *, convert_charrefs: bool = True):
         # This calls HTMLParser.reset() which we override to set up our state.
@@ -190,6 +164,18 @@ class TemplateParser(HTMLParser):
     def append_child(self, child: TNode) -> None:
         parent = self.get_parent()
         parent.children.append(child)
+
+    def get_parser_pos(self) -> FrozenPosition:
+        """
+        Get the current position of the parser.
+
+        @NOTE: This position is relative to text embedded with placeholders but
+        can be translated back to the position within the original template.
+        Since it *IS* relative to placeholders, ie. "SLOTS", this position is
+        unique across a "family" of templates with the same structure.
+        """
+        line, offset = self.getpos()
+        return FrozenPosition(line=line, offset=offset)
 
     # ------------------------------------------
     # Attribute Helpers
@@ -236,18 +222,19 @@ class TemplateParser(HTMLParser):
         self, tag: str, attrs: Sequence[HTMLAttribute], startend: bool = False
     ) -> OpenTag:
         """Build an OpenTag from a raw tag and attribute tuples."""
-        source = self.get_source()
         tag_ref = self.placeholders.remove_placeholders(tag)
         if tag_ref.is_literal:
+            parser_pos = self.get_parser_pos()
             open_tag = OpenTElement(
                 tag=tag,
                 attrs=self.make_tattrs(attrs),
-            )
-            source.record_tag_opening(
-                open_tag,
-                starttag_text=self.get_starttag_text(),
-                raw_attrs=attrs,
-                startend=startend,
+                sinfo=OpenTagSourceInfo(
+                    starttag_text=self.get_starttag_text(),
+                    raw_attrs=tuple(attrs),
+                    startend=startend,
+                    starttag_pos=parser_pos,
+                ),
+                parser_pos=parser_pos,
             )
             return open_tag
 
@@ -287,18 +274,19 @@ class TemplateParser(HTMLParser):
             starttag_text=starttag_text,
         )
 
+        parser_pos = self.get_parser_pos()
         open_tag = OpenTComponent(
             start_i_index=i_index,
             children_start_s_index=children_start_s_index,
             offset_into_children_start_s=offset_into_children_start_s,
             attrs=tattrs,
-        )
-        source.record_tag_opening(
-            open_tag,
-            starttag_text=starttag_text,
-            raw_attrs=attrs,
-            startend=startend,
-        )
+            parser_pos=parser_pos,
+            sinfo=OpenTagSourceInfo(
+                starttag_text=starttag_text,
+                raw_attrs=tuple(attrs),
+                startend=startend,
+                starttag_pos=parser_pos
+            ))
         return open_tag
 
     def compute_offset_into_children_start_s(
@@ -348,20 +336,30 @@ class TemplateParser(HTMLParser):
         return len(tag_ref.strings[-1])
 
     def finalize_tag(
-        self, open_tag: OpenTag, endtag_i_index: int | None = None
+        self, open_tag: OpenTag, endtag_i_index: int | None = None, endtag_pos: FrozenPosition | None = None
     ) -> TNode:
         """Finalize an OpenTag into a TNode."""
         source = self.get_source()
         match open_tag:
-            case OpenTElement(tag=tag, attrs=attrs, children=children):
-                tnode = TElement(tag=tag, attrs=attrs, children=tuple(children))
-            case OpenTFragment(children=children):
-                tnode = TFragment(children=tuple(children))
+            case OpenTElement(
+                tag=tag,
+                attrs=attrs,
+                children=children,
+                parser_pos=parser_pos,
+                sinfo=sinfo
+            ):
+                tnode = TElement(tag=tag, attrs=attrs, children=tuple(children), parser_pos=parser_pos)
+                self.sinfo_table[parser_pos] = sinfo.close(endtag_pos=endtag_pos)
+            case OpenTFragment(children=children, parser_pos=parser_pos):
+                tnode = TFragment(children=tuple(children), parser_pos=parser_pos)
             case OpenTComponent(
                 start_i_index=start_i_index,
                 children_start_s_index=children_start_s_index,
                 offset_into_children_start_s=offset_into_children_start_s,
                 attrs=attrs,
+                parser_pos=parser_pos,
+                sinfo=sinfo,
+                children=children,
             ):
                 children_ref = self.extract_component_children_ref(
                     start_i_index=start_i_index,
@@ -375,8 +373,10 @@ class TemplateParser(HTMLParser):
                     end_i_index=endtag_i_index,
                     children_ref=children_ref,
                     attrs=attrs,
+                    parser_pos=parser_pos
                 )
-        source.record_tag_closing(tnode, open_tag)
+                self.sinfo_table[parser_pos] = sinfo.close(endtag_pos=endtag_pos)
+                self.tcomponent_children[tnode] = children
         return tnode
 
     def extract_component_children_ref(
@@ -456,7 +456,7 @@ class TemplateParser(HTMLParser):
                     e = ValueError(
                         f"Mismatched closing tag </{tag}> for component with tag {{{starttag}}}."
                     )
-                    if self.has_ambiguous_forward_slash(open_tag):
+                    if self.has_ambiguous_forward_slash(open_tag.sinfo):
                         e.add_note(
                             f'Did you mean to quote the last attribute or put a space before "/>" for "<{{{starttag}}} .../>"?'
                         )
@@ -478,7 +478,7 @@ class TemplateParser(HTMLParser):
             raise AssertionError(msg)
         return starttag_text
 
-    def has_ambiguous_forward_slash(self, open_tag: OpenTag) -> bool:
+    def has_ambiguous_forward_slash(self, sinfo: OpenTagSourceInfo | TagSourceInfo | None) -> bool:
         """
         Detect when an unquoted attribute value consumes a trailing "/" that
         *might* have been meant to attempt to self-close a tag, ie. "/>".
@@ -490,20 +490,18 @@ class TemplateParser(HTMLParser):
         Or more often "<{Component} title={title}/>" which should be corrected
         with "<{Component} title={title} />".
         """
-        if isinstance(open_tag, (OpenTElement, OpenTComponent)):
-            source = self.get_source()
-            parse_info = source.get_tag_opening(open_tag)
+        if sinfo is not None:
             return (
                 # has attributes
-                len(parse_info.raw_attrs) > 0
+                len(sinfo.raw_attrs) > 0
                 # last attr not bare attribute
-                and parse_info.raw_attrs[-1][1] is not None
+                and sinfo.raw_attrs[-1][1] is not None
                 # last char of last attr is "/"
-                and parse_info.raw_attrs[-1][1][-1] == "/"
+                and sinfo.raw_attrs[-1][1][-1] == "/"
                 # parsed starttag ends with "/>"
-                and parse_info.starttag_text.endswith("/>")
+                and sinfo.starttag_text.endswith("/>")
                 # if parsed as startend then its not ambiguous
-                and not parse_info.startend
+                and not sinfo.startend
             )
         return False
 
@@ -542,7 +540,8 @@ class TemplateParser(HTMLParser):
             )
         open_tag = self.stack.pop()
         endtag_i_index = self.validate_end_tag(tag, open_tag)
-        final_tag = self.finalize_tag(open_tag, endtag_i_index)
+        final_tag = self.finalize_tag(
+            open_tag, endtag_i_index=endtag_i_index, endtag_pos=self.get_parser_pos())
         self.append_child(final_tag)
 
     def get_closed_tcomps(
@@ -567,8 +566,8 @@ class TemplateParser(HTMLParser):
             if isinstance(node, TComponent):
                 tcomps.append(node)
                 if recurse_component_children:
-                    tag_closing = self.get_source().get_tag_closing(node)
-                    nodes.extend(tag_closing.original_open_tag.children)
+                    children = self.tcomponent_children.get(node, [])
+                    nodes.extend(children)
             elif isinstance(node, (TElement, TFragment)):
                 nodes.extend(node.children)
         return tcomps
@@ -611,6 +610,8 @@ class TemplateParser(HTMLParser):
         self.stack = []
         self.placeholders = PlaceholderState()
         self.source = None
+        self.sinfo_table = {}
+        self.tcomponent_children = {}
 
     def close(self) -> None:
         if self.waiting_for_data():
@@ -630,7 +631,7 @@ class TemplateParser(HTMLParser):
             # this only applies to components.
             parent = self.stack[-1]
             if isinstance(parent, OpenTComponent) and self.has_ambiguous_forward_slash(
-                parent
+                parent.sinfo
             ):
                 # CASE: "<{C1} attr={value}/>" -- meant to self-close
                 # Maybe user meant to self-close?
@@ -652,14 +653,14 @@ class TemplateParser(HTMLParser):
                             comp.start_i_index, comp.end_i_index
                         )
                     ):
-                        tag_closing_info = source.get_tag_closing(comp)
+                        sinfo = self.sinfo_table.get(comp.parser_pos) if comp.parser_pos is not None else None
                         starttag = source.format_starttag(comp.start_i_index)
                         endtag = source.format_endtag(comp.end_i_index)
                         e.add_note(
                             f"Component start tag, <{{{starttag}}}>, and end tag, </{{{endtag}}}>, have values that do not match."
                         )
                         if self.has_ambiguous_forward_slash(
-                            tag_closing_info.original_open_tag
+                            sinfo
                         ):
                             e.add_note(
                                 f'Did you mean to quote the last attribute or put a space before "/>" for "<{{{starttag}}} .../>"?'

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -549,19 +549,16 @@ class TemplateParser(HTMLParser):
             # Check for tags that might have meant to self-close but whose
             # unquoted last attribute value consumed a "/", ie. <div id=app/>.
             parent = self.stack[-1]
-            if isinstance(parent, (OpenTElement, OpenTComponent)):
-                if isinstance(parent, OpenTComponent):
-                    starttag = (
-                        f"{{{self.get_source().format_starttag(parent.start_i_index)}}}"
-                    )
-                else:
-                    starttag = parent.tag
-                if self.has_ambiguous_forward_slash(parent):
-                    e.add_note(
-                        f'Did you mean to quote the last attribute or put a space before "/>" for "<{starttag} .../>"?'
-                    )
-                else:
-                    e.add_note(f"Most recently unclosed tag is <{starttag} ...>")
+            # @TODO: We need to determine which tags this might apply to, this only applies to components.
+            if isinstance(parent, OpenTComponent) and self.has_ambiguous_forward_slash(
+                parent
+            ):
+                starttag = (
+                    f"{{{self.get_source().format_starttag(parent.start_i_index)}}}"
+                )
+                e.add_note(
+                    f'Did you mean to quote the last attribute or put a space before "/>" for "<{starttag} .../>"?'
+                )
             raise e
         if not self.placeholders.is_empty:
             raise ValueError("Some placeholders were never resolved.")

--- a/tdom/parser_test.py
+++ b/tdom/parser_test.py
@@ -672,19 +672,20 @@ def PositionComp() -> Template:
     return t""
 
 
-@pytest.mark.parametrize(
-    "chunk",
-    (
+def test_tnode_parser_position():
+    for tnode_type, fragment in (
         (TElement, t"<span></span>"),
         (TComment, t"<!--ok-->"),
         (TDocumentType, t"<!doctype html>"),
         (TComponent, t"<{PositionComp}></{PositionComp}>"),
         (TText, t"Just a simple text."),
-    ),
-)
-def test_tnode_parser_position(chunk):
-    tnode = TemplateParser.parse(t"<div>" + chunk[1] + t"</div>")
-    assert tnode.tag == "div" and len(tnode.children) == 1
-    el = tnode.children[0]
-    assert isinstance(el, chunk[0])
-    assert el.parser_pos == FrozenPosition(line=1, offset=len("<div>"))
+    ):
+        tnode = TemplateParser.parse(t"<div>" + fragment + t"</div>")
+        assert (
+            isinstance(tnode, TElement)
+            and tnode.tag == "div"
+            and len(tnode.children) == 1
+        )
+        el = tnode.children[0]
+        assert isinstance(el, tnode_type)
+        assert el.parser_pos == FrozenPosition(line=1, offset=len("<div>"))

--- a/tdom/parser_test.py
+++ b/tdom/parser_test.py
@@ -425,17 +425,15 @@ def test_component_element_with_closing_tag():
     assert node == TComponent(start_i_index=0, end_i_index=1)
 
 
-def test_component_element_special_case_mismatched_closing_tag_error():
+def test_component_element_special_case_mismatched_closing_tag_still_parses():
     def Component1():
         pass
 
     def Component2():
         pass
 
-    with pytest.raises(
-        TypeError, match="Component start and end tags must contain the same callable."
-    ):
-        _ = TemplateParser.parse(t"<{Component1}></{Component2}>")
+    node = TemplateParser.parse(t"<{Component1}></{Component2}>")
+    assert node == TComponent(start_i_index=0, end_i_index=1)
 
 
 def test_component_element_invalid_closing_tag():

--- a/tdom/parser_test.py
+++ b/tdom/parser_test.py
@@ -468,6 +468,14 @@ def test_adjacent_end_component_tag_error():
         _ = TemplateParser.parse(t"<{Component}></{Component}{Component}>")
 
 
+def test_unmatched_end_component_tag_error():
+    def Component():
+        pass
+
+    with pytest.raises(ValueError, match="Unexpected closing component tag"):
+        _ = TemplateParser.parse(t"</{Component}>")
+
+
 def test_placeholder_collision_avoidance():
     config = make_placeholder_config()
     # This test is to ensure that our placeholder detection avoids collisions
@@ -604,7 +612,19 @@ class TestComponentExtractChildrenTemplate:
         )
 
 
-class TestComponentUnquotedAttrValue:
+class TestComponentUnquotedAttrValueWithAmbiguousSlash:
+    @pytest.fixture
+    def comp_maker(self):
+        def maker(suffix=None):
+            def _Comp(children: Template, title: str) -> Template:
+                return children
+
+            if suffix is not None:
+                _Comp.__name__ = f"{_Comp.__name__}__{suffix}"
+            return _Comp
+
+        return maker
+
     @pytest.fixture
     def Comp(self):
         def _Comp(children: Template, title: str) -> Template:
@@ -631,6 +651,19 @@ class TestComponentUnquotedAttrValue:
         ):
             _ = TemplateParser.parse(t"<div><{Comp} title=today/></div>")
 
-    def test_comp_unquoted_attr_value_error_nested_in_comp(self, Comp, Comp2):
-        with pytest.raises(TypeError, match="Did you mean to quote the last attribute"):
+    def test_comp_unquoted_attr_value_error_single_nested_in_comp(self, Comp, Comp2):
+        with pytest.raises(
+            ValueError, match="Did you mean to quote the last attribute"
+        ):
             _ = TemplateParser.parse(t"<{Comp2}><{Comp} title=today/></{Comp2}>")
+
+    @pytest.mark.skip()
+    def test_comp_unquoted_attr_value_error_double_nested_in_comp(self, comp_maker):
+        Comp1, Comp2, Comp3 = comp_maker("1"), comp_maker("2"), comp_maker("3")
+        # @TODO: We should warn about this ambig slash.
+        with pytest.raises(
+            ValueError, match="Did you meant to quote the last attribute"
+        ):
+            _ = TemplateParser.parse(
+                t"<{Comp2}><{Comp1}><{Comp3} title=today/></{Comp1}></{Comp2}>"
+            )

--- a/tdom/parser_test.py
+++ b/tdom/parser_test.py
@@ -657,12 +657,10 @@ class TestComponentUnquotedAttrValueWithAmbiguousSlash:
         ):
             _ = TemplateParser.parse(t"<{Comp2}><{Comp} title=today/></{Comp2}>")
 
-    @pytest.mark.skip()
     def test_comp_unquoted_attr_value_error_double_nested_in_comp(self, comp_maker):
         Comp1, Comp2, Comp3 = comp_maker("1"), comp_maker("2"), comp_maker("3")
-        # @TODO: We should warn about this ambig slash.
         with pytest.raises(
-            ValueError, match="Did you meant to quote the last attribute"
+            ValueError, match="Did you mean to quote the last attribute"
         ):
             _ = TemplateParser.parse(
                 t"<{Comp2}><{Comp1}><{Comp3} title=today/></{Comp1}></{Comp2}>"

--- a/tdom/parser_test.py
+++ b/tdom/parser_test.py
@@ -4,6 +4,7 @@ import pytest
 
 from .parser import TemplateParser
 from .placeholders import make_placeholder_config
+from .source import FrozenPosition
 from .template_utils import TemplateRef
 from .tnodes import (
     TComment,
@@ -665,3 +666,25 @@ class TestComponentUnquotedAttrValueWithAmbiguousSlash:
             _ = TemplateParser.parse(
                 t"<{Comp2}><{Comp1}><{Comp3} title=today/></{Comp1}></{Comp2}>"
             )
+
+
+def PositionComp() -> Template:
+    return t""
+
+
+@pytest.mark.parametrize(
+    "chunk",
+    (
+        (TElement, t"<span></span>"),
+        (TComment, t"<!--ok-->"),
+        (TDocumentType, t"<!doctype html>"),
+        (TComponent, t"<{PositionComp}></{PositionComp}>"),
+        (TText, t"Just a simple text."),
+    ),
+)
+def test_tnode_parser_position(chunk):
+    tnode = TemplateParser.parse(t"<div>" + chunk[1] + t"</div>")
+    assert tnode.tag == "div" and len(tnode.children) == 1
+    el = tnode.children[0]
+    assert isinstance(el, chunk[0])
+    assert el.parser_pos == FrozenPosition(line=1, offset=len("<div>"))

--- a/tdom/parser_test.py
+++ b/tdom/parser_test.py
@@ -425,15 +425,17 @@ def test_component_element_with_closing_tag():
     assert node == TComponent(start_i_index=0, end_i_index=1)
 
 
-def test_component_element_special_case_mismatched_closing_tag_still_parses():
+def test_component_element_special_case_mismatched_closing_tag_error():
     def Component1():
         pass
 
     def Component2():
         pass
 
-    node = TemplateParser.parse(t"<{Component1}></{Component2}>")
-    assert node == TComponent(start_i_index=0, end_i_index=1)
+    with pytest.raises(
+        TypeError, match="Component start and end tags must contain the same callable."
+    ):
+        _ = TemplateParser.parse(t"<{Component1}></{Component2}>")
 
 
 def test_component_element_invalid_closing_tag():
@@ -602,3 +604,35 @@ class TestComponentExtractChildrenTemplate:
                 strings=("<div>Hello, World!</div>",), i_indexes=()
             ),
         )
+
+
+class TestComponentUnquotedAttrValue:
+    @pytest.fixture
+    def Comp(self):
+        def _Comp(children: Template, title: str) -> Template:
+            return children
+
+        return _Comp
+
+    @pytest.fixture
+    def Comp2(self):
+        def _Comp2(children: Template, title: str) -> Template:
+            return children
+
+        return _Comp2
+
+    def test_comp_unquoted_attr_value_error_root(self, Comp):
+        with pytest.raises(
+            ValueError, match="Did you mean to quote the last attribute"
+        ):
+            _ = TemplateParser.parse(t"<{Comp} title=today/>")
+
+    def test_comp_unquoted_attr_value_error_nested_in_el(self, Comp):
+        with pytest.raises(
+            ValueError, match="Did you mean to quote the last attribute"
+        ):
+            _ = TemplateParser.parse(t"<div><{Comp} title=today/></div>")
+
+    def test_comp_unquoted_attr_value_error_nested_in_comp(self, Comp, Comp2):
+        with pytest.raises(TypeError, match="Did you mean to quote the last attribute"):
+            _ = TemplateParser.parse(t"<{Comp2}><{Comp} title=today/></{Comp2}>")

--- a/tdom/parser_utils.py
+++ b/tdom/parser_utils.py
@@ -1,0 +1,1 @@
+type HTMLAttribute = tuple[str, str | None]

--- a/tdom/placeholders.py
+++ b/tdom/placeholders.py
@@ -61,6 +61,9 @@ class PlaceholderState:
     config: PlaceholderConfig = field(default_factory=make_placeholder_config)
     """Collection of currently 'known and active' placeholder indexes."""
 
+    def copy(self):
+        return PlaceholderState(known=self.known.copy(), config=self.config)
+
     @property
     def is_empty(self) -> bool:
         return len(self.known) == 0

--- a/tdom/source.py
+++ b/tdom/source.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+
+from .parser_utils import HTMLAttribute
+
+
+@dataclass(slots=True, frozen=True)
+class FrozenPosition:
+    "A immutable position in a block of source code."
+
+    line: int = 1
+    " Line of code, starts at 1. "
+    offset: int = 0
+    " Offset from the start of the line, starts at 0. "
+
+
+@dataclass(slots=True)
+class Position:
+    "A position in a block of source code."
+
+    line: int = 1
+    " Line of code, starts at 1. "
+    offset: int = 0
+    " Offset from the start of the line, starts at 0. "
+
+    def freeze(self) -> FrozenPosition:
+        return FrozenPosition(line=self.line, offset=self.offset)
+
+
+@dataclass(frozen=True, slots=True)
+class TagSourceInfo:
+    """
+    Retained tag information from the parsed source.
+
+    @NOTE: These properties DEPEND on the placeholder configuration because
+    they can contain embedded placeholders.
+    """
+    starttag_text: str
+    " Entire starttag as parsed, includes placeholders, . "
+    raw_attrs: tuple[HTMLAttribute, ...]
+    " Attrs as parsed, includes placeholders. "
+    startend: bool
+    " Was parsed as startend tag, ie. <tag />. "
+    starttag_pos: FrozenPosition
+    " Position of the parser when the element starttag was parsed. "
+    endtag_pos: FrozenPosition | None = None
+    " Position of the parser when the element endtag was parsed. "

--- a/tdom/source.py
+++ b/tdom/source.py
@@ -34,6 +34,7 @@ class TagSourceInfo:
     @NOTE: These properties DEPEND on the placeholder configuration because
     they can contain embedded placeholders.
     """
+
     starttag_text: str
     " Entire starttag as parsed, includes placeholders, . "
     raw_attrs: tuple[HTMLAttribute, ...]

--- a/tdom/tnodes.py
+++ b/tdom/tnodes.py
@@ -1,6 +1,7 @@
 import typing as t
 from dataclasses import dataclass, field
 
+from .source import FrozenPosition
 from .template_utils import TemplateRef
 
 
@@ -45,6 +46,8 @@ class TNode:
 class TText(TNode):
     ref: TemplateRef
 
+    parser_pos: FrozenPosition | None = field(default=None, compare=False)
+
     @classmethod
     def empty(cls) -> t.Self:
         return cls(TemplateRef.empty())
@@ -58,6 +61,8 @@ class TText(TNode):
 class TComment(TNode):
     ref: TemplateRef
 
+    parser_pos: FrozenPosition | None = field(default=None, compare=False)
+
     @classmethod
     def literal(cls, text: str) -> t.Self:
         return cls(TemplateRef.literal(text))
@@ -67,10 +72,14 @@ class TComment(TNode):
 class TDocumentType(TNode):
     text: str
 
+    parser_pos: FrozenPosition | None = field(default=None, compare=False)
+
 
 @dataclass(slots=True, frozen=True)
 class TFragment(TNode):
     children: tuple[TNode, ...] = field(default_factory=tuple)
+
+    parser_pos: FrozenPosition | None = field(default=None, compare=False)
 
 
 @dataclass(slots=True, frozen=True)
@@ -78,6 +87,8 @@ class TElement(TNode):
     tag: str
     attrs: tuple[TAttribute, ...] = field(default_factory=tuple)
     children: tuple[TNode, ...] = field(default_factory=tuple)
+
+    parser_pos: FrozenPosition | None = field(default=None, compare=False)
 
 
 @dataclass(slots=True, frozen=True)
@@ -94,6 +105,8 @@ class TComponent(TNode):
     """The template ref that describes the component's children template."""
 
     attrs: tuple[TAttribute, ...] = field(default_factory=tuple)
+
+    parser_pos: FrozenPosition | None = field(default=None, compare=False)
 
 
 type TTag = TElement | TComponent | TFragment


### PR DESCRIPTION
Try to give more detailed error messages when a component's unquoted attribute consumes the "/" AND an error occurs where it is not closed.

This is the first step in trying to get through #132 

Examples that fail but were meant to probably self-close the component: 
    - `t"<{Comp} title={title}/>"`
    - `t"<div><{Comp} title={title}/></div>"` 
    - `t"<{Comp2}><{Comp1} title={title}/></{Comp2}>""`

The last example requires inspecting the interpolations to resolve that `Comp1 != Comp2`.

This brings up a past issue we tried to skip over where this would parse but fail processing:
- `t"<{Comp1}></{Comp2}>"`
