### PR TITLE
Use `Mapping` in place of `dict` for `isinstance` check in "spread", data, aria, class and style attributes.

### DIFF
--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -1,5 +1,5 @@
 import typing as t
-from collections.abc import Callable, Iterable, Sequence, Mapping
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from functools import lru_cache
 from string.templatelib import Interpolation, Template

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -1,5 +1,5 @@
 import typing as t
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence, Mapping
 from dataclasses import dataclass, field
 from functools import lru_cache
 from string.templatelib import Interpolation, Template
@@ -100,7 +100,7 @@ def _expand_aria_attr(value: object) -> Iterable[HTMLAttribute]:
     """Produce aria-* attributes based on the interpolated value for "aria"."""
     if value is None:
         return
-    elif isinstance(value, dict):
+    elif isinstance(value, Mapping):
         for sub_k, sub_v in value.items():
             if sub_v is True:
                 yield f"aria-{sub_k}", "true"
@@ -120,7 +120,7 @@ def _expand_data_attr(value: object) -> Iterable[Attribute]:
     """Produce data-* attributes based on the interpolated value for "data"."""
     if value is None:
         return
-    elif isinstance(value, dict):
+    elif isinstance(value, Mapping):
         for sub_k, sub_v in value.items():
             if sub_v is True or sub_v is False or sub_v is None:
                 yield f"data-{sub_k}", sub_v
@@ -138,11 +138,11 @@ def _substitute_spread_attrs(value: object) -> Iterable[Attribute]:
 
     A spread attribute is one where the key is a placeholder, indicating that
     the entire attribute set should be replaced by the interpolated value.
-    The value must be a dict or iterable of key-value pairs.
+    The value must be a Mapping.
     """
     if value is None:
         return
-    elif isinstance(value, dict):
+    elif isinstance(value, Mapping):
         yield from value.items()
     else:
         raise TypeError(
@@ -202,7 +202,7 @@ class StyleAccumulator:
                 self.styles.update(
                     {name: value for name, value in parse_style_attribute_value(value)}
                 )
-            case dict():
+            case Mapping():
                 self.styles.update(
                     {
                         str(pn): str(pv) if pv is not None else None
@@ -250,7 +250,7 @@ class ClassAccumulator:
         """
         Merge in an interpolated class value.
         """
-        if isinstance(value, dict):
+        if isinstance(value, Mapping):
             self.toggled_classes.update(
                 {str(cn): bool(toggle) for cn, toggle in value.items()}
             )

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -1260,7 +1260,10 @@ class TestSpecialAriaAttribute:
 
     def test_interpolated_mapping(self):
         aria_dict = {"label": "Close", "hidden": True, "another": False, "more": None}
-        for aria_mapping in (aria_dict, UserDict(aria_dict.items())): # dict and non-dict Mapping
+        for aria_mapping in (
+            aria_dict,
+            UserDict(aria_dict.items()),
+        ):  # dict and non-dict Mapping
             res = html(t"<button aria={aria_mapping}>X</button>")
             assert (
                 res
@@ -1312,12 +1315,14 @@ class TestSpecialClassAttribute:
 
     def test_interpolated_mapping(self):
         class_dict = {"active": True, "btn-secondary": False}
-        for class_mapping in (class_dict, UserDict(class_dict.items())): # dict and non-dict Mapping
-            res = html(t"<button class='btn-secondary' class={class_mapping}>X</button>")
-            assert (
-                res
-                == '<button class="active">X</button>'
+        for class_mapping in (
+            class_dict,
+            UserDict(class_dict.items()),
+        ):  # dict and non-dict Mapping
+            res = html(
+                t"<button class='btn-secondary' class={class_mapping}>X</button>"
             )
+            assert res == '<button class="active">X</button>'
 
     def test_interpolated_class_attribute_with_multiple_placeholders(self):
         classes1 = ["btn", "btn-primary"]

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -1,5 +1,6 @@
 import datetime
 import typing as t
+from collections import UserDict
 from collections.abc import Callable
 from dataclasses import dataclass
 from itertools import chain, product
@@ -1257,13 +1258,14 @@ class TestSpecialAriaAttribute:
         with pytest.raises(TypeError):
             _ = html(t'<div aria="{aria1} {aria2}"></div>')
 
-    def test_aria_interpolated_attr_dict(self):
-        aria = {"label": "Close", "hidden": True, "another": False, "more": None}
-        res = html(t"<button aria={aria}>X</button>")
-        assert (
-            res
-            == '<button aria-label="Close" aria-hidden="true" aria-another="false">X</button>'
-        )
+    def test_interpolated_mapping(self):
+        aria_dict = {"label": "Close", "hidden": True, "another": False, "more": None}
+        for aria_mapping in (aria_dict, UserDict(aria_dict.items())): # dict and non-dict Mapping
+            res = html(t"<button aria={aria_mapping}>X</button>")
+            assert (
+                res
+                == '<button aria-label="Close" aria-hidden="true" aria-another="false">X</button>'
+            )
 
     def test_aria_interpolate_attr_none(self):
         button_aria = None
@@ -1307,6 +1309,15 @@ class TestSpecialClassAttribute:
             res
             == '<button class="red btn btn-primary one two active blue green yellow">Click me</button>'
         )
+
+    def test_interpolated_mapping(self):
+        class_dict = {"active": True, "btn-secondary": False}
+        for class_mapping in (class_dict, UserDict(class_dict.items())): # dict and non-dict Mapping
+            res = html(t"<button class='btn-secondary' class={class_mapping}>X</button>")
+            assert (
+                res
+                == '<button class="active">X</button>'
+            )
 
     def test_interpolated_class_attribute_with_multiple_placeholders(self):
         classes1 = ["btn", "btn-primary"]


### PR DESCRIPTION
Most of the builtins are subclasses of `dict` but libraries might implement their own dict-like implementations.  This seems more Pythonic, and we already use `Sequence`, `isinstance(v, Mapping)` is slower but we'll have to tackle that some other way.  Possibly with some sort of attribute caching scheme that would bypass all the checks anyways.

We use `UserDict` (which is not a subclass of `dict`) to test this in a few tests but adding it to every case feels a little redundant since we are using a regular dict in the tests which is a `Mapping` already.

We already should not be mutating the user's input anyways so `Mapping` is a good for that check as well.