### PR TITLE
Consolidate placeholder tracking in the source tracker.

### DIFF
--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -1,10 +1,16 @@
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from html.parser import HTMLParser
-from string.templatelib import Interpolation, Template
+from string.templatelib import Template
 
 from .htmlspec import VOID_ELEMENTS
-from .placeholders import PlaceholderState
+from .placeholders import (
+    PlaceholderConfig,
+    PlaceholderState,
+)
+from .placeholders import (
+    make_placeholder_config as default_make_placeholder_config,
+)
 from .template_utils import TemplateRef, combine_template_refs
 from .tnodes import (
     TAttribute,
@@ -55,31 +61,70 @@ class OpenTComponent:
 type OpenTag = OpenTElement | OpenTFragment | OpenTComponent
 
 
+def configure_source_tracker(
+    template: Template,
+    make_placeholder_config: Callable[
+        [], PlaceholderConfig
+    ] = default_make_placeholder_config,
+) -> SourceTracker:
+    config = make_placeholder_config()
+    return SourceTracker(
+        template=template, placeholders=PlaceholderState(config=config)
+    )
+
+
 @dataclass
 class SourceTracker:
-    """Tracks source locations within a Template for error reporting."""
-
-    # TODO: write utilities to generate complete error messages, with the
-    # template itself in context and the relevant line/column underlined/etc.
+    """
+    Iterator of template parts that adds placeholders to interpolations.
+    """
 
     template: Template
-    # if i_index >= s_index, feeding an interpolation;
-    # otherwise, when i_index < s_index, feeding a string.
-    i_index: int = -1  # The current interpolation index.
-    s_index: int = -1  # The current string index.
 
-    @property
-    def interpolations(self) -> tuple[Interpolation, ...]:
-        return self.template.interpolations
+    placeholders: PlaceholderState
 
-    def advance_interpolation(self) -> int:
-        """Call before processing an interpolation to move to the next one."""
-        self.i_index += 1
-        return self.i_index
+    index: int = -1
+    " Unified template index that moves over interpolations and strings. "
 
-    def advance_string(self) -> int:
-        self.s_index += 1
-        return self.s_index
+    def __iter__(self):
+        #
+        # @NOTE: This iterator is only meant to be used once since we track
+        # placeholders both by adding them and letting the user remove them
+        # with calls to `remove_placeholders()`.
+        return self
+
+    def __next__(self):
+        if self.index < 2 * len(self.template.strings) - 2:
+            self.index += 1
+            if self.index % 2 == 0:
+                return self.template.strings[self.index // 2]
+            else:
+                return self.placeholders.add_placeholder((self.index - 1) // 2)
+        else:
+            raise StopIteration
+
+    def remove_placeholders(self, text: str) -> TemplateRef:
+        """
+        Find tracked placeholders in text and mark them as found.
+
+        @NOTE: Raises if any untracked placeholders are found.
+
+        If you want to make a TemplateRef without changing state use
+        `self.find_placeholders()`.
+        """
+        return self.placeholders.remove_placeholders(text)
+
+    def find_placeholders(self, text: str) -> TemplateRef:
+        """
+        Find all placeholders without affecting tracking.
+        """
+        return self.placeholders.config.find_placeholders(text)
+
+    def has_placeholders(self) -> bool:
+        """
+        Determine if known placeholders still remain.
+        """
+        return not self.placeholders.is_empty
 
     def get_expression(
         self, i_index: int, fallback_prefix: str = "interpolation"
@@ -88,7 +133,7 @@ class SourceTracker:
         Resolve an interpolation index to its original expression for error messages.
         Falls back to a synthetic expression if the original is empty.
         """
-        ip = self.interpolations[i_index]
+        ip = self.template.interpolations[i_index]
         return ip.expression if ip.expression else f"{{{fallback_prefix}-{i_index}}}"
 
     def format_starttag(self, i_index: int) -> str:
@@ -99,7 +144,6 @@ class SourceTracker:
 class TemplateParser(HTMLParser):
     root: OpenTFragment
     stack: list[OpenTag]
-    placeholders: PlaceholderState
     source: SourceTracker | None
 
     def __init__(self, *, convert_charrefs: bool = True):
@@ -124,13 +168,12 @@ class TemplateParser(HTMLParser):
 
     def make_tattr(self, attr: HTMLAttribute) -> TAttribute:
         """Build a TAttribute from a raw attribute tuple."""
+        source = self.get_source()
 
         name, value = attr
 
-        name_ref = self.placeholders.remove_placeholders(name)
-        value_ref = (
-            self.placeholders.remove_placeholders(value) if value is not None else None
-        )
+        name_ref = source.remove_placeholders(name)
+        value_ref = source.remove_placeholders(value) if value is not None else None
 
         if name_ref.is_literal:
             if value_ref is None or value_ref.is_literal:
@@ -161,7 +204,9 @@ class TemplateParser(HTMLParser):
 
     def make_open_tag(self, tag: str, attrs: Sequence[HTMLAttribute]) -> OpenTag:
         """Build an OpenTag from a raw tag and attribute tuples."""
-        tag_ref = self.placeholders.remove_placeholders(tag)
+        source = self.get_source()
+
+        tag_ref = source.remove_placeholders(tag)
 
         if tag_ref.is_literal:
             return OpenTElement(tag=tag, attrs=self.make_tattrs(attrs))
@@ -284,7 +329,7 @@ class TemplateParser(HTMLParser):
     def validate_end_tag(self, tag: str, open_tag: OpenTag) -> int | None:
         """Validate that closing tag matches open tag. Return component end index if applicable."""
         source = self.get_source()
-        tag_ref = self.placeholders.remove_placeholders(tag)
+        tag_ref = source.remove_placeholders(tag)
 
         match open_tag:
             case OpenTElement():
@@ -320,10 +365,11 @@ class TemplateParser(HTMLParser):
         Wrap get_starttag_text and just raise if None is returned.
         Do this so we don't guard for `None` everywhere.
         """
+        source = self.get_source()
         starttag_text = self.get_starttag_text()
         if starttag_text is None:
             raise AssertionError("Expected the parser to have starttag_text set.")
-        return self.placeholders.config.find_placeholders(starttag_text)
+        return source.find_placeholders(starttag_text)
 
     # ------------------------------------------
     # HTMLParser tag callbacks
@@ -357,7 +403,8 @@ class TemplateParser(HTMLParser):
     # ------------------------------------------
 
     def handle_data(self, data: str) -> None:
-        ref = self.placeholders.remove_placeholders(data)
+        source = self.get_source()
+        ref = source.remove_placeholders(data)
         parent = self.get_parent()
         if parent.children and isinstance(parent.children[-1], TText):
             parent.children[-1] = TText(
@@ -367,12 +414,14 @@ class TemplateParser(HTMLParser):
             self.append_child(TText(ref=ref))
 
     def handle_comment(self, data: str) -> None:
-        ref = self.placeholders.remove_placeholders(data)
+        source = self.get_source()
+        ref = source.remove_placeholders(data)
         comment = TComment(ref)
         self.append_child(comment)
 
     def handle_decl(self, decl: str) -> None:
-        ref = self.placeholders.remove_placeholders(decl)
+        source = self.get_source()
+        ref = source.remove_placeholders(decl)
         if not ref.is_literal:
             raise ValueError("Interpolations are not allowed in declarations.")
         elif decl.upper().startswith("DOCTYPE "):
@@ -388,7 +437,6 @@ class TemplateParser(HTMLParser):
         super().reset()
         self.root = OpenTFragment()
         self.stack = []
-        self.placeholders = PlaceholderState()
         self.source = None
 
     def close(self) -> None:
@@ -404,7 +452,7 @@ class TemplateParser(HTMLParser):
                 )
         if self.stack:
             raise ValueError("Invalid HTML structure: unclosed tags remain.")
-        if not self.placeholders.is_empty:
+        if self.source and self.source.has_placeholders():
             raise ValueError("Some placeholders were never resolved.")
         super().close()
 
@@ -441,25 +489,16 @@ class TemplateParser(HTMLParser):
             raise AssertionError("Source has not been initialized.")
         return self.source
 
-    def feed_str(self, s: str) -> None:
-        """Feed a string part of a Template to the parser."""
-        self.feed(s)
-
-    def feed_interpolation(self, index: int) -> None:
-        placeholder = self.placeholders.add_placeholder(index)
-        self.feed(placeholder)
+    def track_source(self, template: Template) -> SourceTracker:
+        if self.source:
+            raise AssertionError("Did you forget to call reset?")
+        source = self.source = configure_source_tracker(template)
+        return source
 
     def feed_template(self, template: Template) -> None:
         """Feed a Template's content to the parser."""
-        assert self.source is None, "Did you forget to call reset?"
-        self.source = SourceTracker(template)
-        for i_index in range(len(template.interpolations)):
-            self.source.advance_string()
-            self.feed_str(template.strings[i_index])
-            self.source.advance_interpolation()
-            self.feed_interpolation(i_index)
-        self.source.advance_string()
-        self.feed_str(template.strings[-1])
+        for content in self.track_source(template):
+            self.feed(content)
 
     @staticmethod
     def parse(t: Template) -> TNode:

--- a/tdom/parser_test.py
+++ b/tdom/parser_test.py
@@ -2,7 +2,7 @@ from string.templatelib import Interpolation, Template
 
 import pytest
 
-from .parser import TemplateParser
+from .parser import TemplateParser, configure_source_tracker
 from .placeholders import make_placeholder_config
 from .template_utils import TemplateRef
 from .tnodes import (
@@ -494,6 +494,34 @@ def test_unresolved_placeholder():
     tp.get_source().placeholders.add_placeholder(3)
     with pytest.raises(ValueError, match="Some placeholders were never resolved"):
         tp.close()
+
+
+class TestSourceTracker:
+    def test_iter(self):
+        t = t"<div>{0}</div>"
+        st = configure_source_tracker(t)
+        itr = iter(st)
+        parts = []
+        parts.append(next(itr))
+        assert itr.index == 0
+        assert not itr.has_placeholders()
+        assert parts[0] == t.strings[0], "String parts pass through."
+        parts.append(next(itr))
+        assert itr.index == 1
+        assert itr.has_placeholders(), "Placeholder was addeded."
+        tref_find = st.find_placeholders(parts[1])
+        assert itr.has_placeholders() and tref_find.i_indexes[0] == 0
+        tref_removed = st.remove_placeholders(parts[1])
+        assert not itr.has_placeholders() and tref_removed.i_indexes[0] == 0, (
+            "Placeholder removed."
+        )
+        parts.append(next(itr))
+        assert itr.index == 2
+        with pytest.raises(StopIteration):
+            next(itr)
+        assert itr.index == 2, (
+            "Once the iter is exhausted the index remains at the last element."
+        )
 
 
 class TestIncompleteParsing:

--- a/tdom/parser_test.py
+++ b/tdom/parser_test.py
@@ -497,6 +497,17 @@ def test_unresolved_placeholder():
 
 
 class TestSourceTracker:
+    @pytest.mark.parametrize("t", (t"", t"simple"))
+    def test_only_string(self, t: Template):
+        st = configure_source_tracker(t)
+        itr = iter(st)
+        part = next(itr)
+        assert isinstance(part, str) and part == t.strings[0]
+        assert itr.index == 0
+        with pytest.raises(StopIteration):
+            _ = next(itr)
+        assert itr.index == 0, "Still at 0."
+
     def test_iter(self):
         t = t"<div>{0}</div>"
         st = configure_source_tracker(t)

--- a/tdom/parser_test.py
+++ b/tdom/parser_test.py
@@ -485,6 +485,17 @@ def test_placeholder_collision_avoidance():
     )
 
 
+def test_unresolved_placeholder():
+    t = t"<div>{0}<span>{1}</span>{2}</div>"
+    tp = TemplateParser()
+    tp.feed_template(t)
+    # This would be a bug in the parser so we have to fabricate
+    # this error manually.
+    tp.get_source().placeholders.add_placeholder(3)
+    with pytest.raises(ValueError, match="Some placeholders were never resolved"):
+        tp.close()
+
+
 class TestIncompleteParsing:
     def test_dangling_quotes(self):
         with pytest.raises(ValueError, match="Parser expects more data"):


### PR DESCRIPTION
- Morph `SourceTracker` into an Iterator.
- Move placeholder injection (and tracking) internally into the `SourceTracker`.
- Redirect `TemplateParser`'s placeholder extraction to proxy methods of the `SourceTracker.  The parser still needs to know when its just looking at a snapshot versus when it is "marking" the placeholder as found.  Not ideal but this composition feels better and more distinct from the regular parsing duties.
- Use `configure_source_tracker` factory function because later we bind the `PlaceholderConfig` to members other than `PlaceholderState` that depend on the size of the placeholders (defined by the config).

The `SourceTracker` methods `get_expression` and `format_starttag` will be removed in another PR and those responsibilities will be in the `SourceReader` (constructed and accessed during exceptions).