### PR TITLE
Make the docs site findable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A 🤘 rockin' t-string HTML templating system for Python 3.14.
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/t-strings/tdom/blob/main/LICENSE)
 [![Docs](https://img.shields.io/badge/docs-online-blue.svg)](https://t-strings.github.io/tdom/)
 
+**Documentation:** <https://t-strings.github.io/tdom/>
+
 ## NOTE WELL
 
 This is pre-alpha software. It is still under heavy development and the API may change without warning. We would love community feedback to help shape the direction of this project!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
 
 [project.urls]
 Homepage = "https://github.com/t-strings/tdom"
+Documentation = "https://t-strings.github.io/tdom/"
 Changelog = "https://github.com/t-strings/tdom/releases"
 Issues = "https://github.com/t-strings/tdom/issues"
 CI = "https://github.com/t-strings/tdom/actions"


### PR DESCRIPTION
PyPI renders a **Documentation** link in its project sidebar from `[project.urls]`, and we never declared one. The only pointer to the docs site anywhere in the repo was a shields.io badge sitting eighth in a row of seven — so in practice nothing led anyone there.

Two small changes:

- Add `Documentation = "https://t-strings.github.io/tdom/"` to `[project.urls]`.
- Add one line of prose under the badges in the README.

Note that the PyPI sidebar link won't appear until the next release is published — this only affects metadata for future builds.