### PR TITLE
Compute and store position of TNodes during parsing for improved error messages.

### DIFF
--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -4,6 +4,11 @@ from html.parser import HTMLParser
 from string.templatelib import Template
 
 from .htmlspec import VOID_ELEMENTS
+from .parser_utils import (
+    HTMLAttribute,
+    ParserPositionTranslator,
+    make_parser_pos_translator,
+)
 from .placeholders import (
     PlaceholderConfig,
     PlaceholderState,
@@ -11,8 +16,10 @@ from .placeholders import (
 from .placeholders import (
     make_placeholder_config as default_make_placeholder_config,
 )
-from .template_utils import TemplateRef, combine_template_refs
+from .source import LinePosition
+from .template_utils import PartPosition, TemplateRef, combine_template_refs
 from .tnodes import (
+    TagSourceInfo,
     TAttribute,
     TComment,
     TComponent,
@@ -25,21 +32,47 @@ from .tnodes import (
     TSpreadAttribute,
     TTemplatedAttribute,
     TText,
+    TTree,
 )
 
-type HTMLAttribute = tuple[str, str | None]
-type HTMLAttributesDict = dict[str, str | None]
+
+@dataclass(frozen=True, slots=True)
+class OpenTagSourceInfo:
+    """
+    Retained tag information from the parsed source meant for error reporting.
+
+    @NOTE: This is an temporary structure that will be finalized when the
+    tag is closed.
+    """
+
+    starttag_ref: TemplateRef
+    " Entire starttag as parsed except placeholders are replaced by references. "
+    startend: bool
+    " Was parsed as startend tag, ie. <tag />. "
+    starttag_pos: PartPosition
+    " Template part position of the starttag. "
+
+    def close(self, endtag_pos: PartPosition | None = None) -> TagSourceInfo:
+        return TagSourceInfo(
+            starttag_ref=self.starttag_ref,
+            startend=self.startend,
+            starttag_pos=self.starttag_pos,
+            endtag_pos=endtag_pos,
+        )
 
 
 @dataclass
 class OpenTElement:
     tag: str
     attrs: tuple[TAttribute, ...]
+    source_pos: PartPosition
+    sinfo: OpenTagSourceInfo
     children: list[TNode] = field(default_factory=list)
 
 
 @dataclass
 class OpenTFragment:
+    source_pos: PartPosition | None = None
     children: list[TNode] = field(default_factory=list)
 
 
@@ -51,6 +84,8 @@ class OpenTComponent:
     offset_into_children_start_s: int
     """The offset INTO the starting string where the component's children template starts."""
     attrs: tuple[TAttribute, ...]
+    source_pos: PartPosition
+    sinfo: OpenTagSourceInfo
     # @NOTE: The `children` are discarded after parsing and are just used to
     # track template consistency.  If the component is processed and
     # returns its children template then that template will be
@@ -67,9 +102,14 @@ def configure_source_tracker(
         [], PlaceholderConfig
     ] = default_make_placeholder_config,
 ) -> SourceTracker:
+    """
+    Configure and return source tracker with its subcomponents.
+    """
     config = make_placeholder_config()
     return SourceTracker(
-        template=template, placeholders=PlaceholderState(config=config)
+        template=template,
+        placeholders=PlaceholderState(config=config),
+        parser_pos_translator=make_parser_pos_translator(template, config),
     )
 
 
@@ -82,6 +122,9 @@ class SourceTracker:
     template: Template
 
     placeholders: PlaceholderState
+
+    parser_pos_translator: ParserPositionTranslator
+    "Translator from parser position to template part position. "
 
     index: int = -1
     " Unified template index that moves over interpolations and strings. "
@@ -126,6 +169,12 @@ class SourceTracker:
         """
         return not self.placeholders.is_empty
 
+    def translate_parser_pos(self, raw_parser_pos: LinePosition) -> PartPosition:
+        """
+        Translate a parser position to a part position within the template.
+        """
+        return self.parser_pos_translator.translate(raw_parser_pos)
+
     def get_expression(
         self, i_index: int, fallback_prefix: str = "interpolation"
     ) -> str:
@@ -146,6 +195,9 @@ class TemplateParser(HTMLParser):
     stack: list[OpenTag]
     source: SourceTracker | None
 
+    sinfo_table: dict[PartPosition, TagSourceInfo]
+    " Tags with more source info than just a position are tracked in this mapping. "
+
     def __init__(self, *, convert_charrefs: bool = True):
         # This calls HTMLParser.reset() which we override to set up our state.
         super().__init__(convert_charrefs=convert_charrefs)
@@ -161,6 +213,25 @@ class TemplateParser(HTMLParser):
     def append_child(self, child: TNode) -> None:
         parent = self.get_parent()
         parent.children.append(child)
+
+    def get_parser_pos(self) -> LinePosition:
+        """
+        Get the current position of the parser.
+
+        @NOTE: This position is relative to text embedded with placeholders but
+        can be translated back to the position within the original template.
+        Since it *IS* relative to placeholders, ie. "SLOTS", this position is
+        unique across a "family" of templates with the same structure.
+        """
+        line, offset = self.getpos()
+        return LinePosition(line=line, offset=offset)
+
+    def get_source_pos(self, parser_pos: LinePosition | None = None) -> PartPosition:
+        "Translate the parser position into a part position in the source template."
+        source = self.get_source()
+        return source.translate_parser_pos(
+            self.get_parser_pos() if parser_pos is None else parser_pos
+        )
 
     # ------------------------------------------
     # Attribute Helpers
@@ -202,14 +273,29 @@ class TemplateParser(HTMLParser):
     # Tag Helpers
     # ------------------------------------------
 
-    def make_open_tag(self, tag: str, attrs: Sequence[HTMLAttribute]) -> OpenTag:
+    def make_open_tag(
+        self,
+        tag: str,
+        attrs: Sequence[HTMLAttribute],
+        startend: bool = False,
+    ) -> OpenTag:
         """Build an OpenTag from a raw tag and attribute tuples."""
         source = self.get_source()
 
         tag_ref = source.remove_placeholders(tag)
 
         if tag_ref.is_literal:
-            return OpenTElement(tag=tag, attrs=self.make_tattrs(attrs))
+            source_pos = self.get_source_pos()
+            return OpenTElement(
+                tag=tag,
+                attrs=self.make_tattrs(attrs),
+                sinfo=OpenTagSourceInfo(
+                    starttag_ref=self.get_starttag_ref(),
+                    startend=startend,
+                    starttag_pos=source_pos,
+                ),
+                source_pos=source_pos,
+            )
 
         if not tag_ref.is_singleton:
             raise ValueError(
@@ -239,41 +325,73 @@ class TemplateParser(HTMLParser):
         # of the children's leading string.
         offset_into_children_start_s = len(starttag_ref.strings[-1])
 
+        source_pos = self.get_source_pos()
+
         return OpenTComponent(
             start_i_index=i_index,
             children_start_s_index=children_start_s_index,
             offset_into_children_start_s=offset_into_children_start_s,
             attrs=self.make_tattrs(attrs),
+            source_pos=source_pos,
+            sinfo=OpenTagSourceInfo(
+                starttag_ref=starttag_ref,
+                startend=startend,
+                starttag_pos=source_pos,
+            ),
         )
 
     def finalize_tag(
-        self, open_tag: OpenTag, endtag_i_index: int | None = None
+        self,
+        open_tag: OpenTag,
+        endtag_i_index: int | None = None,
+        endtag_pos: PartPosition | None = None,
     ) -> TNode:
         """Finalize an OpenTag into a TNode."""
+        source = self.get_source()
         match open_tag:
-            case OpenTElement(tag=tag, attrs=attrs, children=children):
-                return TElement(tag=tag, attrs=attrs, children=tuple(children))
-            case OpenTFragment(children=children):
-                return TFragment(children=tuple(children))
+            case OpenTElement(
+                tag=tag,
+                attrs=attrs,
+                children=children,
+                source_pos=source_pos,
+                sinfo=sinfo,
+            ):
+                tnode = TElement(
+                    tag=tag,
+                    attrs=attrs,
+                    children=tuple(children),
+                    source_pos=source_pos,
+                )
+                source_pos = (
+                    open_tag.source_pos
+                )  # Re-assignment for ty regression in 0.0.59
+                self.sinfo_table[source_pos] = sinfo.close(endtag_pos=endtag_pos)
+            case OpenTFragment(children=children, source_pos=source_pos):
+                tnode = TFragment(children=tuple(children), source_pos=source_pos)
             case OpenTComponent(
                 start_i_index=start_i_index,
                 children_start_s_index=children_start_s_index,
                 offset_into_children_start_s=offset_into_children_start_s,
                 attrs=attrs,
+                source_pos=source_pos,
+                sinfo=sinfo,
             ):
                 children_ref = self.extract_component_children_ref(
                     start_i_index=start_i_index,
                     endtag_i_index=endtag_i_index,
                     children_start_s_index=children_start_s_index,
                     offset_into_children_start_s=offset_into_children_start_s,
-                    template=self.get_source().template,
+                    template=source.template,
                 )
-                return TComponent(
+                self.sinfo_table[source_pos] = sinfo.close(endtag_pos=endtag_pos)
+                tnode = TComponent(
                     start_i_index=start_i_index,
                     end_i_index=endtag_i_index,
                     children_ref=children_ref,
                     attrs=attrs,
+                    source_pos=source_pos,
                 )
+        return tnode
 
     def extract_component_children_ref(
         self,
@@ -385,17 +503,20 @@ class TemplateParser(HTMLParser):
 
     def handle_startendtag(self, tag: str, attrs: Sequence[HTMLAttribute]) -> None:
         """Dispatch a self-closing tag, `<tag />` to specialized handlers."""
-        open_tag = self.make_open_tag(tag, attrs)
+        open_tag = self.make_open_tag(tag, attrs, startend=True)
         final_tag = self.finalize_tag(open_tag)
         self.append_child(final_tag)
 
     def handle_endtag(self, tag: str) -> None:
+        endtag_pos = self.get_source_pos()
         if not self.stack:
             raise ValueError(f"Unexpected closing tag </{tag}> with no open tag.")
 
         open_tag = self.stack.pop()
         endtag_i_index = self.validate_end_tag(tag, open_tag)
-        final_tag = self.finalize_tag(open_tag, endtag_i_index)
+        final_tag = self.finalize_tag(
+            open_tag, endtag_i_index=endtag_i_index, endtag_pos=endtag_pos
+        )
         self.append_child(final_tag)
 
     # ------------------------------------------
@@ -407,16 +528,19 @@ class TemplateParser(HTMLParser):
         ref = source.remove_placeholders(data)
         parent = self.get_parent()
         if parent.children and isinstance(parent.children[-1], TText):
+            prior_text = parent.children[-1]
             parent.children[-1] = TText(
-                ref=combine_template_refs(parent.children[-1].ref, ref)
+                ref=combine_template_refs(parent.children[-1].ref, ref),
+                # Keep starting position of the prior text
+                source_pos=prior_text.source_pos,
             )
         else:
-            self.append_child(TText(ref=ref))
+            self.append_child(TText(ref=ref, source_pos=self.get_source_pos()))
 
     def handle_comment(self, data: str) -> None:
         source = self.get_source()
         ref = source.remove_placeholders(data)
-        comment = TComment(ref)
+        comment = TComment(ref, source_pos=self.get_source_pos())
         self.append_child(comment)
 
     def handle_decl(self, decl: str) -> None:
@@ -426,7 +550,7 @@ class TemplateParser(HTMLParser):
             raise ValueError("Interpolations are not allowed in declarations.")
         elif decl.upper().startswith("DOCTYPE "):
             doctype_content = decl[7:].strip()
-            doctype = TDocumentType(doctype_content)
+            doctype = TDocumentType(doctype_content, source_pos=self.get_source_pos())
             self.append_child(doctype)
         else:
             raise NotImplementedError(
@@ -438,6 +562,7 @@ class TemplateParser(HTMLParser):
         self.root = OpenTFragment()
         self.stack = []
         self.source = None
+        self.sinfo_table = {}
 
     def close(self) -> None:
         if self.waiting_for_data():
@@ -480,6 +605,12 @@ class TemplateParser(HTMLParser):
             # CONSIDER: or as an empty text node?
             return self.finalize_tag(self.root)
 
+    def get_ttree(self) -> TTree:
+        return TTree(
+            self.get_tnode(),
+            sinfos=tuple(self.sinfo_table.values()),
+        )
+
     # ------------------------------------------
     # Feeding and parsing
     # ------------------------------------------
@@ -507,7 +638,12 @@ class TemplateParser(HTMLParser):
         a TNode tree representing its structure. This cachable structure can later
         be resolved against actual interpolation values to produce a Node tree.
         """
+        ttree = TemplateParser.parse_to_ttree(t)
+        return ttree.root
+
+    @staticmethod
+    def parse_to_ttree(t: Template) -> TTree:
         parser = TemplateParser()
         parser.feed_template(t)
         parser.close()
-        return parser.get_tnode()
+        return parser.get_ttree()

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -631,17 +631,12 @@ class TemplateParser(HTMLParser):
             self.feed(content)
 
     @staticmethod
-    def parse(t: Template) -> TNode:
+    def parse(t: Template) -> TTree:
         """
         Parse a Template containing valid HTML and substitutions and return
-        a TNode tree representing its structure. This cachable structure can later
-        be resolved against actual interpolation values to produce a Node tree.
+        a TTree representing its structure. This cachable structure can later
+        be resolved against actual interpolation values to produce HTML.
         """
-        ttree = TemplateParser.parse_to_ttree(t)
-        return ttree.root
-
-    @staticmethod
-    def parse_to_ttree(t: Template) -> TTree:
         parser = TemplateParser()
         parser.feed_template(t)
         parser.close()

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -356,18 +356,18 @@ class TemplateParser(HTMLParser):
                 source_pos=source_pos,
                 sinfo=sinfo,
             ):
-                tnode = TElement(
+                source_pos = (
+                    open_tag.source_pos
+                )  # Re-assignment for ty regression in 0.0.59
+                self.sinfo_table[source_pos] = sinfo.close(endtag_pos=endtag_pos)
+                return TElement(
                     tag=tag,
                     attrs=attrs,
                     children=tuple(children),
                     source_pos=source_pos,
                 )
-                source_pos = (
-                    open_tag.source_pos
-                )  # Re-assignment for ty regression in 0.0.59
-                self.sinfo_table[source_pos] = sinfo.close(endtag_pos=endtag_pos)
             case OpenTFragment(children=children, source_pos=source_pos):
-                tnode = TFragment(children=tuple(children), source_pos=source_pos)
+                return TFragment(children=tuple(children), source_pos=source_pos)
             case OpenTComponent(
                 start_i_index=start_i_index,
                 children_start_s_index=children_start_s_index,
@@ -384,14 +384,13 @@ class TemplateParser(HTMLParser):
                     template=source.template,
                 )
                 self.sinfo_table[source_pos] = sinfo.close(endtag_pos=endtag_pos)
-                tnode = TComponent(
+                return TComponent(
                     start_i_index=start_i_index,
                     end_i_index=endtag_i_index,
                     children_ref=children_ref,
                     attrs=attrs,
                     source_pos=source_pos,
                 )
-        return tnode
 
     def extract_component_children_ref(
         self,

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -530,7 +530,7 @@ class TemplateParser(HTMLParser):
         if parent.children and isinstance(parent.children[-1], TText):
             prior_text = parent.children[-1]
             parent.children[-1] = TText(
-                ref=combine_template_refs(parent.children[-1].ref, ref),
+                ref=combine_template_refs(prior_text.ref, ref),
                 # Keep starting position of the prior text
                 source_pos=prior_text.source_pos,
             )

--- a/tdom/parser_test.py
+++ b/tdom/parser_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from .parser import TemplateParser, configure_source_tracker
 from .placeholders import make_placeholder_config
-from .template_utils import TemplateRef
+from .template_utils import PartPosition, TemplateRef
 from .tnodes import (
     TComment,
     TComponent,
@@ -652,3 +652,155 @@ class TestComponentExtractChildrenTemplate:
                 strings=("<div>Hello, World!</div>",), i_indexes=()
             ),
         )
+
+
+class TestSourcePos:
+    """
+    Test that common nodes have a source position translated and set during parsing.
+    """
+
+    @pytest.mark.parametrize(
+        ("t", "part_pos"),
+        (
+            (t"ABC<div></div>", PartPosition(0, offset=len("ABC"))),
+            (t"{' '}<div></div>", PartPosition(2, offset=0)),
+        ),
+    )
+    def test_el(self, t: Template, part_pos: PartPosition):
+        ttree = TemplateParser.parse_to_ttree(t)
+        assert isinstance(ttree.root, TFragment)
+        node = ttree.root.children[1]
+        assert isinstance(node, TElement) and node.source_pos == part_pos
+
+    @pytest.mark.parametrize(
+        ("t", "part_pos"),
+        (
+            (t"<div></div>ABC", PartPosition(0, offset=len("<div></div>"))),
+            (t"<div>{' '}</div>ABC", PartPosition(2, offset=len("</div>"))),
+        ),
+    )
+    def test_text(self, t: Template, part_pos: PartPosition):
+        ttree = TemplateParser.parse_to_ttree(t)
+        assert isinstance(ttree.root, TFragment)
+        node = ttree.root.children[1]
+        assert isinstance(node, TText) and node.source_pos == part_pos
+
+    @pytest.mark.parametrize(
+        ("t", "part_pos"),
+        (
+            (t"  <!doctype html>", PartPosition(0, offset=2)),
+            (t"{' '}<!doctype html>", PartPosition(2, 0)),
+        ),
+    )
+    def test_doctype(self, t: Template, part_pos: PartPosition):
+        ttree = TemplateParser.parse_to_ttree(t)
+        assert isinstance(ttree.root, TFragment)
+        node = ttree.root.children[1]
+        assert isinstance(node, TDocumentType) and node.source_pos == part_pos
+
+    @pytest.mark.parametrize(
+        ("t", "part_pos"),
+        (
+            (t"  <!--comment-->", PartPosition(0, offset=2)),
+            (t"<div>{'ABC'}</div><!--comment-->", PartPosition(2, len("</div>"))),
+        ),
+    )
+    def test_comment(self, t: Template, part_pos: PartPosition):
+        ttree = TemplateParser.parse_to_ttree(t)
+        assert isinstance(ttree.root, TFragment)
+        node = ttree.root.children[1]
+        assert isinstance(node, TComment) and node.source_pos == part_pos
+
+    def test_component(self):
+        def Comp() -> Template:
+            return t""
+
+        for t, part_pos in (
+            (t"  <{Comp} />", PartPosition(0, offset=len("  "))),
+            (t"  {'ABC'}DEF<{Comp} />", PartPosition(2, offset=len("DEF"))),
+        ):
+            ttree = TemplateParser.parse_to_ttree(t)
+            assert isinstance(ttree.root, TFragment)
+            node = ttree.root.children[1]
+            assert isinstance(node, TComponent) and node.source_pos == part_pos
+
+
+class TestSourceInfo:
+    """
+    Test that elements and components have correct entries in the sinfo_table after parsing.
+    """
+
+    def test_el(self):
+        ttree = TemplateParser.parse_to_ttree(t"<div></div>")
+        sinfo_table = ttree.unpack_sinfo_table()
+        node = ttree.root
+        assert (
+            isinstance(node, TElement)
+            and sinfo_table
+            and node.source_pos is not None
+            and node.source_pos in sinfo_table
+        )
+        sinfo = sinfo_table[node.source_pos]
+        assert sinfo.startend == False
+        assert sinfo.starttag_pos == PartPosition(
+            0, 0
+        ) and sinfo.endtag_pos == PartPosition(0, len("<div>"))
+        assert sinfo.starttag_ref.strings == ("<div>",)
+
+    def test_el_self_closed(self):
+        ttree = TemplateParser.parse_to_ttree(t"<div />")
+        sinfo_table = ttree.unpack_sinfo_table()
+        node = ttree.root
+        assert (
+            isinstance(node, TElement)
+            and sinfo_table
+            and node.source_pos is not None
+            and node.source_pos in sinfo_table
+        )
+        sinfo = sinfo_table[node.source_pos]
+        assert sinfo.startend == True
+        assert sinfo.starttag_pos == PartPosition(0, 0) and sinfo.endtag_pos is None
+        assert sinfo.starttag_ref.strings == ("<div />",)
+
+    def test_component(self):
+        def Comp() -> Template:
+            return t""
+
+        ttree = TemplateParser.parse_to_ttree(t"<{Comp}></{Comp}>")
+        sinfo_table = ttree.unpack_sinfo_table()
+        node = ttree.root
+        assert (
+            isinstance(node, TComponent)
+            and sinfo_table
+            and node.source_pos is not None
+            and node.source_pos in sinfo_table
+        )
+        sinfo = sinfo_table[node.source_pos]
+        assert sinfo.startend == False
+        assert sinfo.starttag_pos == PartPosition(
+            0, 0
+        ) and sinfo.endtag_pos == PartPosition(2, len(">"))
+        assert sinfo.starttag_ref.strings == ("<", ">")
+
+    def test_component_self_closed(self):
+        def Comp() -> Template:
+            return t""
+
+        ttree = TemplateParser.parse_to_ttree(t"<{Comp} />")
+        sinfo_table = ttree.unpack_sinfo_table()
+        node = ttree.root
+        assert (
+            isinstance(node, TComponent)
+            and sinfo_table
+            and node.source_pos is not None
+            and node.source_pos in sinfo_table
+        )
+        sinfo = sinfo_table[node.source_pos]
+        assert sinfo.startend == True
+        assert sinfo.starttag_pos == PartPosition(0, 0) and sinfo.endtag_pos is None
+        assert sinfo.starttag_ref.strings == ("<", " />")
+
+    def test_empty_sinfo_table(self):
+        ttree = TemplateParser.parse_to_ttree(t"<!doctype html>ABC")
+        sinfo_table = ttree.unpack_sinfo_table()
+        assert not sinfo_table

--- a/tdom/parser_test.py
+++ b/tdom/parser_test.py
@@ -13,14 +13,20 @@ from .tnodes import (
     TFragment,
     TInterpolatedAttribute,
     TLiteralAttribute,
+    TNode,
     TSpreadAttribute,
     TTemplatedAttribute,
     TText,
 )
 
 
+def parse_root(t: Template) -> TNode:
+    """Parse template to ttree and then return the root tnode."""
+    return TemplateParser.parse(t).root
+
+
 def test_parse_mixed_literal_content():
-    node = TemplateParser.parse(
+    node = parse_root(
         t"<!DOCTYPE html>"
         t"<!-- Comment -->"
         t'<div class="container">'
@@ -50,17 +56,17 @@ def test_parse_mixed_literal_content():
 # Text
 #
 def test_parse_empty():
-    node = TemplateParser.parse(t"")
+    node = parse_root(t"")
     assert node == TFragment()
 
 
 def test_parse_text():
-    node = TemplateParser.parse(t"Hello, world!")
+    node = parse_root(t"Hello, world!")
     assert node == TText.literal("Hello, world!")
 
 
 def test_parse_text_multiline():
-    node = TemplateParser.parse(t"""Hello, world!
+    node = parse_root(t"""Hello, world!
   Hello, moon!
 Hello, sun!
 """)
@@ -71,19 +77,19 @@ Hello, sun!
 
 
 def test_parse_text_with_entities():
-    node = TemplateParser.parse(t"a &lt; b")
+    node = parse_root(t"a &lt; b")
     assert node == TText.literal("a < b")
 
 
 def test_parse_text_with_template_singleton():
     greeting = "Hello, World!"
-    node = TemplateParser.parse(t"{greeting}")
+    node = parse_root(t"{greeting}")
     assert node == TText(ref=TemplateRef(strings=("", ""), i_indexes=(0,)))
 
 
 def test_parse_text_with_template():
     who = "World"
-    node = TemplateParser.parse(t"Hello, {who}!")
+    node = parse_root(t"Hello, {who}!")
     assert node == TText(ref=TemplateRef(strings=("Hello, ", "!"), i_indexes=(0,)))
 
 
@@ -91,27 +97,27 @@ def test_parse_text_with_template():
 # Elements
 #
 def test_parse_void_element():
-    node = TemplateParser.parse(t"<br>")
+    node = parse_root(t"<br>")
     assert node == TElement("br")
 
 
 def test_parse_void_element_self_closed():
-    node = TemplateParser.parse(t"<br />")
+    node = parse_root(t"<br />")
     assert node == TElement("br")
 
 
 def test_parse_uppercase_void_element():
-    node = TemplateParser.parse(t"<BR>")
+    node = parse_root(t"<BR>")
     assert node == TElement("br")
 
 
 def test_parse_standard_element_with_text():
-    node = TemplateParser.parse(t"<div>Hello, world!</div>")
+    node = parse_root(t"<div>Hello, world!</div>")
     assert node == TElement("div", children=(TText.literal("Hello, world!"),))
 
 
 def test_parse_nested_elements():
-    node = TemplateParser.parse(t"<div><span>Nested</span> content</div>")
+    node = parse_root(t"<div><span>Nested</span> content</div>")
     assert node == TElement(
         "div",
         children=(
@@ -123,7 +129,7 @@ def test_parse_nested_elements():
 
 def test_parse_element_with_template():
     who = "World"
-    node = TemplateParser.parse(t"<div>Hello, {who}!</div>")
+    node = parse_root(t"<div>Hello, {who}!</div>")
     assert node == TElement(
         "div",
         children=(TText(ref=TemplateRef(strings=("Hello, ", "!"), i_indexes=(0,))),),
@@ -132,14 +138,14 @@ def test_parse_element_with_template():
 
 def test_parse_element_with_template_singleton():
     greeting = "Hello, World!"
-    node = TemplateParser.parse(t"<div>{greeting}</div>")
+    node = parse_root(t"<div>{greeting}</div>")
     assert node == TElement(
         "div", children=(TText(ref=TemplateRef(strings=("", ""), i_indexes=(0,))),)
     )
 
 
 def test_parse_multiple_voids():
-    node = TemplateParser.parse(t"<br><hr><hr /><hr /><br /><br><br>")
+    node = parse_root(t"<br><hr><hr /><hr /><br /><br><br>")
     assert node == TFragment(
         children=(
             TElement("br"),
@@ -154,7 +160,7 @@ def test_parse_multiple_voids():
 
 
 def test_parse_text_entities():
-    node = TemplateParser.parse(t"<p>&lt;/p&gt;</p>")
+    node = parse_root(t"<p>&lt;/p&gt;</p>")
     assert node == TElement(
         "p",
         children=(TText.literal("</p>"),),
@@ -162,9 +168,7 @@ def test_parse_text_entities():
 
 
 def test_parse_script_tag_content():
-    node = TemplateParser.parse(
-        t"<script>if (a < b && c > d) {{ alert('wow'); }}</script>"
-    )
+    node = parse_root(t"<script>if (a < b && c > d) {{ alert('wow'); }}</script>")
     assert node == TElement(
         "script",
         children=(TText.literal("if (a < b && c > d) { alert('wow'); }"),),
@@ -173,7 +177,7 @@ def test_parse_script_tag_content():
 
 def test_parse_script_with_entities():
     # The <script> tag (and <style>) tag uses the CDATA content model.
-    node = TemplateParser.parse(t"<script>var x = 'a &amp; b';</script>")
+    node = parse_root(t"<script>var x = 'a &amp; b';</script>")
     assert node == TElement(
         "script",
         children=(TText.literal("var x = 'a &amp; b';"),),
@@ -181,9 +185,7 @@ def test_parse_script_with_entities():
 
 
 def test_parse_textarea_tag_content():
-    node = TemplateParser.parse(
-        t"<textarea>if (a < b && c > d) {{ alert('wow'); }}</textarea>"
-    )
+    node = parse_root(t"<textarea>if (a < b && c > d) {{ alert('wow'); }}</textarea>")
     assert node == TElement(
         "textarea",
         children=(TText.literal("if (a < b && c > d) { alert('wow'); }"),),
@@ -192,7 +194,7 @@ def test_parse_textarea_tag_content():
 
 def test_parse_textarea_with_entities():
     # The <textarea> (and <title>) tag uses the RCDATA content model.
-    node = TemplateParser.parse(t"<textarea>var x = 'a &amp; b';</textarea>")
+    node = parse_root(t"<textarea>var x = 'a &amp; b';</textarea>")
     assert node == TElement(
         "textarea",
         children=(TText.literal("var x = 'a & b';"),),
@@ -200,7 +202,7 @@ def test_parse_textarea_with_entities():
 
 
 def test_parse_title_unusual():
-    node = TemplateParser.parse(t"<title>My & Awesome <Site></title>")
+    node = parse_root(t"<title>My & Awesome <Site></title>")
     assert node == TElement(
         "title",
         children=(TText.literal("My & Awesome <Site>"),),
@@ -209,21 +211,21 @@ def test_parse_title_unusual():
 
 def test_parse_mismatched_tags():
     with pytest.raises(ValueError):
-        _ = TemplateParser.parse(t"<div><span>Mismatched</div></span>")
+        _ = parse_root(t"<div><span>Mismatched</div></span>")
 
 
 def test_parse_unclosed_tag():
     with pytest.raises(ValueError):
-        _ = TemplateParser.parse(t"<div>Unclosed")
+        _ = parse_root(t"<div>Unclosed")
 
 
 def test_parse_unexpected_closing_tag():
     with pytest.raises(ValueError):
-        _ = TemplateParser.parse(t"Unopened</div>")
+        _ = parse_root(t"Unopened</div>")
 
 
 def test_self_closing_tags():
-    node = TemplateParser.parse(t"<div/><p></p>")
+    node = parse_root(t"<div/><p></p>")
     assert node == TFragment(
         children=(
             TElement("div"),
@@ -233,29 +235,29 @@ def test_self_closing_tags():
 
 
 def test_nested_self_closing_tags():
-    node = TemplateParser.parse(t"<div><br><div /><br></div>")
+    node = parse_root(t"<div><br><div /><br></div>")
     assert node == TElement(
         "div", children=(TElement("br"), TElement("div"), TElement("br"))
     )
-    node = TemplateParser.parse(t"<div><div /></div>")
+    node = parse_root(t"<div><div /></div>")
     assert node == TElement("div", children=(TElement("div"),))
 
 
 def test_self_closing_tags_unexpected_closing_tag():
     with pytest.raises(ValueError):
-        _ = TemplateParser.parse(t"<div /></div>")
+        _ = parse_root(t"<div /></div>")
 
 
 def test_self_closing_void_tags_unexpected_closing_tag():
     with pytest.raises(ValueError):
-        _ = TemplateParser.parse(t"<input /></input>")
+        _ = parse_root(t"<input /></input>")
 
 
 #
 # Attributes
 #
 def test_literal_attrs():
-    node = TemplateParser.parse(
+    node = parse_root(
         t"<a"
         t" id=example_link"  # no quotes allowed without spaces
         t" autofocus"  # bare / boolean
@@ -277,7 +279,7 @@ def test_literal_attrs():
 
 
 def test_literal_attr_entities():
-    node = TemplateParser.parse(t'<a title="&lt;">Link</a>')
+    node = parse_root(t'<a title="&lt;">Link</a>')
     assert node == TElement(
         "a",
         attrs=(TLiteralAttribute("title", "<"),),
@@ -286,7 +288,7 @@ def test_literal_attr_entities():
 
 
 def test_literal_attr_order():
-    node = TemplateParser.parse(t'<a title="a" href="b" title="c"></a>')
+    node = parse_root(t'<a title="a" href="b" title="c"></a>')
     assert isinstance(node, TElement)
     assert node.attrs == (
         TLiteralAttribute("title", "a"),
@@ -298,7 +300,7 @@ def test_literal_attr_order():
 def test_interpolated_attr():
     value1 = 42
     value2 = 99
-    node = TemplateParser.parse(t'<div value1="{value1}" value2={value2} />')
+    node = parse_root(t'<div value1="{value1}" value2={value2} />')
     assert node == TElement(
         "div",
         attrs=(
@@ -312,9 +314,7 @@ def test_interpolated_attr():
 def test_templated_attr():
     value1 = 42
     value2 = 99
-    node = TemplateParser.parse(
-        t'<div value1="{value1}-burrito" value2="neato-{value2}-wow" />'
-    )
+    node = parse_root(t'<div value1="{value1}-burrito" value2="neato-{value2}-wow" />')
     value1_ref = TemplateRef(strings=("", "-burrito"), i_indexes=(0,))
     value2_ref = TemplateRef(strings=("neato-", "-wow"), i_indexes=(1,))
     assert node == TElement(
@@ -329,7 +329,7 @@ def test_templated_attr():
 
 def test_spread_attr():
     spread_attrs = {}
-    node = TemplateParser.parse(t"<div {spread_attrs} />")
+    node = parse_root(t"<div {spread_attrs} />")
     assert node == TElement(
         "div",
         attrs=(TSpreadAttribute(i_index=0),),
@@ -340,34 +340,34 @@ def test_spread_attr():
 def test_templated_attribute_name_error():
     with pytest.raises(ValueError):
         attr_name = "some-attr"
-        _ = TemplateParser.parse(t'<div {attr_name}="value" />')
+        _ = parse_root(t'<div {attr_name}="value" />')
 
 
 def test_templated_attribute_name_and_value_error():
     with pytest.raises(ValueError):
         attr_name = "some-attr"
         value = "value"
-        _ = TemplateParser.parse(t'<div {attr_name}="{value}" />')
+        _ = parse_root(t'<div {attr_name}="{value}" />')
 
 
 def test_adjacent_spread_attrs_error():
     with pytest.raises(ValueError):
         attrs1 = {}
         attrs2 = {}
-        _ = TemplateParser.parse(t"<div {attrs1}{attrs2} />")
+        _ = parse_root(t"<div {attrs1}{attrs2} />")
 
 
 #
 # Comments
 #
 def test_parse_comment():
-    node = TemplateParser.parse(t"<!-- This is a comment -->")
+    node = parse_root(t"<!-- This is a comment -->")
     assert node == TComment.literal(" This is a comment ")
 
 
 def test_parse_comment_interpolation():
     text = "comment"
-    node = TemplateParser.parse(t"<!-- This is a {text} -->")
+    node = parse_root(t"<!-- This is a {text} -->")
     assert node == TComment(
         ref=TemplateRef(strings=(" This is a ", " "), i_indexes=(0,))
     )
@@ -377,21 +377,21 @@ def test_parse_comment_interpolation():
 # Doctypes
 #
 def test_parse_doctype():
-    node = TemplateParser.parse(t"<!DOCTYPE html>")
+    node = parse_root(t"<!DOCTYPE html>")
     assert node == TDocumentType("html")
 
 
 def test_parse_doctype_interpolation_error():
     extra = "SYSTEM"
     with pytest.raises(ValueError):
-        _ = TemplateParser.parse(t"<!DOCTYPE html {extra}>")
+        _ = parse_root(t"<!DOCTYPE html {extra}>")
 
 
 def test_unsupported_decl_error():
     with pytest.raises(NotImplementedError):
-        _ = TemplateParser.parse(t"<!doctype-alt html500>")  # Unknown declaration
+        _ = parse_root(t"<!doctype-alt html500>")  # Unknown declaration
     with pytest.raises(NotImplementedError):
-        _ = TemplateParser.parse(t"<!doctype>")  # missing DTD
+        _ = parse_root(t"<!doctype>")  # missing DTD
 
 
 #
@@ -401,7 +401,7 @@ def test_component_element_with_children():
     def Component(children):
         return t"{children}"
 
-    node = TemplateParser.parse(t"<{Component}><div>Hello, World!</div></{Component}>")
+    node = parse_root(t"<{Component}><div>Hello, World!</div></{Component}>")
     assert node == TComponent(
         start_i_index=0,
         end_i_index=1,
@@ -413,7 +413,7 @@ def test_component_element_self_closing():
     def Component():
         pass
 
-    node = TemplateParser.parse(t"<{Component} />")
+    node = parse_root(t"<{Component} />")
     assert node == TComponent(start_i_index=0)
 
 
@@ -421,7 +421,7 @@ def test_component_element_with_closing_tag():
     def Component():
         pass
 
-    node = TemplateParser.parse(t"<{Component}></{Component}>")
+    node = parse_root(t"<{Component}></{Component}>")
     assert node == TComponent(start_i_index=0, end_i_index=1)
 
 
@@ -432,7 +432,7 @@ def test_component_element_special_case_mismatched_closing_tag_still_parses():
     def Component2():
         pass
 
-    node = TemplateParser.parse(t"<{Component1}></{Component2}>")
+    node = parse_root(t"<{Component1}></{Component2}>")
     assert node == TComponent(start_i_index=0, end_i_index=1)
 
 
@@ -441,7 +441,7 @@ def test_component_element_invalid_closing_tag():
         pass
 
     with pytest.raises(ValueError):
-        _ = TemplateParser.parse(t"<{Component}></div>")
+        _ = parse_root(t"<{Component}></div>")
 
 
 def test_component_element_invalid_opening_tag():
@@ -449,7 +449,7 @@ def test_component_element_invalid_opening_tag():
         pass
 
     with pytest.raises(ValueError):
-        _ = TemplateParser.parse(t"<div></{Component}>")
+        _ = parse_root(t"<div></{Component}>")
 
 
 def test_adjacent_start_component_tag_error():
@@ -457,7 +457,7 @@ def test_adjacent_start_component_tag_error():
         pass
 
     with pytest.raises(ValueError):
-        _ = TemplateParser.parse(t"<{Component}{Component}></{Component}>")
+        _ = parse_root(t"<{Component}{Component}></{Component}>")
 
 
 def test_adjacent_end_component_tag_error():
@@ -465,7 +465,7 @@ def test_adjacent_end_component_tag_error():
         pass
 
     with pytest.raises(ValueError):
-        _ = TemplateParser.parse(t"<{Component}></{Component}{Component}>")
+        _ = parse_root(t"<{Component}></{Component}{Component}>")
 
 
 def test_placeholder_collision_avoidance():
@@ -478,7 +478,7 @@ def test_placeholder_collision_avoidance():
         Interpolation(tricky, "tricky", None, ""),
         f'{config.suffix}"></div>',
     )
-    tnode = TemplateParser.parse(template)
+    tnode = parse_root(template)
     value_ref = TemplateRef(strings=(config.prefix, config.suffix), i_indexes=(0,))
     assert tnode == TElement(
         "div", attrs=(TTemplatedAttribute(name="data-tricky", value_ref=value_ref),)
@@ -538,17 +538,17 @@ class TestSourceTracker:
 class TestIncompleteParsing:
     def test_dangling_quotes(self):
         with pytest.raises(ValueError, match="Parser expects more data"):
-            _ = TemplateParser.parse(t"<div a='")
+            _ = parse_root(t"<div a='")
         with pytest.raises(ValueError, match="Parser expects more data"):
-            _ = TemplateParser.parse(t'<div a="')
+            _ = parse_root(t'<div a="')
 
     def test_unfinished_attribute(self):
         with pytest.raises(ValueError, match="Parser expects more data"):
-            _ = TemplateParser.parse(t"<div a=")
+            _ = parse_root(t"<div a=")
 
     def test_placeholder_missing_from_dangling_quote(self):
         with pytest.raises(ValueError, match="Parser expects more data"):
-            _ = TemplateParser.parse(t'<div a="{None}')
+            _ = parse_root(t'<div a="{None}')
 
 
 class TestComponentExtractChildrenTemplate:
@@ -560,7 +560,7 @@ class TestComponentExtractChildrenTemplate:
         return Component
 
     def test_extract_no_content(self, Component):
-        node = TemplateParser.parse(t"<{Component}></{Component}>")
+        node = parse_root(t"<{Component}></{Component}>")
         assert node == TComponent(
             start_i_index=0,
             end_i_index=1,
@@ -568,7 +568,7 @@ class TestComponentExtractChildrenTemplate:
         )
 
     def test_extract_startend(self, Component):
-        node = TemplateParser.parse(t"<{Component} />")
+        node = parse_root(t"<{Component} />")
         assert node == TComponent(
             start_i_index=0,
             end_i_index=None,
@@ -576,9 +576,7 @@ class TestComponentExtractChildrenTemplate:
         )
 
     def test_extract(self, Component):
-        node = TemplateParser.parse(
-            t"<{Component}><div>Hello, World!</div></{Component}>"
-        )
+        node = parse_root(t"<{Component}><div>Hello, World!</div></{Component}>")
         assert node == TComponent(
             start_i_index=0,
             end_i_index=1,
@@ -589,7 +587,7 @@ class TestComponentExtractChildrenTemplate:
 
     def test_extract_with_attr_interpolation(self, Component):
         # Unquoted ...
-        node = TemplateParser.parse(
+        node = parse_root(
             t"<{Component} title={'Skip over this.'}><div>Hello, World!</div></{Component}>"
         )
         assert node == TComponent(
@@ -601,13 +599,13 @@ class TestComponentExtractChildrenTemplate:
             ),
         )
         # Quoted...
-        node2 = TemplateParser.parse(
+        node2 = parse_root(
             t'<{Component} title="{"Skip over this."}"><div>Hello, World!</div></{Component}>'
         )
         assert node2 == node
 
     def test_extract_with_literal_attr_gt_char(self, Component):
-        node = TemplateParser.parse(
+        node = parse_root(
             t'<{Component} title="1 > 0"><div>Hello, World!</div></{Component}>'
         )
         assert node == TComponent(
@@ -620,7 +618,7 @@ class TestComponentExtractChildrenTemplate:
         )
 
     def test_extract_with_interpolated_attr_literal_attr_gt_char(self, Component):
-        node = TemplateParser.parse(
+        node = parse_root(
             t'<{Component} id={"simple"} title="1 > 0"><div>Hello, World!</div></{Component}>'
         )
         assert node == TComponent(
@@ -636,7 +634,7 @@ class TestComponentExtractChildrenTemplate:
         )
 
     def test_extract_with_templated_attr_gt_char(self, Component):
-        node = TemplateParser.parse(
+        node = parse_root(
             t'<{Component} id="{"header"}_{"container"}" title="1 > 0"><div>Hello, World!</div></{Component}>'
         )
         assert node == TComponent(
@@ -667,9 +665,9 @@ class TestSourcePos:
         ),
     )
     def test_el(self, t: Template, part_pos: PartPosition):
-        ttree = TemplateParser.parse_to_ttree(t)
-        assert isinstance(ttree.root, TFragment)
-        node = ttree.root.children[1]
+        root = parse_root(t)
+        assert isinstance(root, TFragment)
+        node = root.children[1]
         assert isinstance(node, TElement) and node.source_pos == part_pos
 
     @pytest.mark.parametrize(
@@ -680,9 +678,9 @@ class TestSourcePos:
         ),
     )
     def test_text(self, t: Template, part_pos: PartPosition):
-        ttree = TemplateParser.parse_to_ttree(t)
-        assert isinstance(ttree.root, TFragment)
-        node = ttree.root.children[1]
+        root = parse_root(t)
+        assert isinstance(root, TFragment)
+        node = root.children[1]
         assert isinstance(node, TText) and node.source_pos == part_pos
 
     @pytest.mark.parametrize(
@@ -693,9 +691,9 @@ class TestSourcePos:
         ),
     )
     def test_doctype(self, t: Template, part_pos: PartPosition):
-        ttree = TemplateParser.parse_to_ttree(t)
-        assert isinstance(ttree.root, TFragment)
-        node = ttree.root.children[1]
+        root = parse_root(t)
+        assert isinstance(root, TFragment)
+        node = root.children[1]
         assert isinstance(node, TDocumentType) and node.source_pos == part_pos
 
     @pytest.mark.parametrize(
@@ -706,9 +704,9 @@ class TestSourcePos:
         ),
     )
     def test_comment(self, t: Template, part_pos: PartPosition):
-        ttree = TemplateParser.parse_to_ttree(t)
-        assert isinstance(ttree.root, TFragment)
-        node = ttree.root.children[1]
+        root = parse_root(t)
+        assert isinstance(root, TFragment)
+        node = root.children[1]
         assert isinstance(node, TComment) and node.source_pos == part_pos
 
     def test_component(self):
@@ -719,9 +717,9 @@ class TestSourcePos:
             (t"  <{Comp} />", PartPosition(0, offset=len("  "))),
             (t"  {'ABC'}DEF<{Comp} />", PartPosition(2, offset=len("DEF"))),
         ):
-            ttree = TemplateParser.parse_to_ttree(t)
-            assert isinstance(ttree.root, TFragment)
-            node = ttree.root.children[1]
+            root = parse_root(t)
+            assert isinstance(root, TFragment)
+            node = root.children[1]
             assert isinstance(node, TComponent) and node.source_pos == part_pos
 
 
@@ -731,7 +729,7 @@ class TestSourceInfo:
     """
 
     def test_el(self):
-        ttree = TemplateParser.parse_to_ttree(t"<div></div>")
+        ttree = TemplateParser.parse(t"<div></div>")
         sinfo_table = ttree.unpack_sinfo_table()
         node = ttree.root
         assert (
@@ -748,7 +746,7 @@ class TestSourceInfo:
         assert sinfo.starttag_ref.strings == ("<div>",)
 
     def test_el_self_closed(self):
-        ttree = TemplateParser.parse_to_ttree(t"<div />")
+        ttree = TemplateParser.parse(t"<div />")
         sinfo_table = ttree.unpack_sinfo_table()
         node = ttree.root
         assert (
@@ -766,7 +764,7 @@ class TestSourceInfo:
         def Comp() -> Template:
             return t""
 
-        ttree = TemplateParser.parse_to_ttree(t"<{Comp}></{Comp}>")
+        ttree = TemplateParser.parse(t"<{Comp}></{Comp}>")
         sinfo_table = ttree.unpack_sinfo_table()
         node = ttree.root
         assert (
@@ -786,7 +784,7 @@ class TestSourceInfo:
         def Comp() -> Template:
             return t""
 
-        ttree = TemplateParser.parse_to_ttree(t"<{Comp} />")
+        ttree = TemplateParser.parse(t"<{Comp} />")
         sinfo_table = ttree.unpack_sinfo_table()
         node = ttree.root
         assert (
@@ -801,6 +799,6 @@ class TestSourceInfo:
         assert sinfo.starttag_ref.strings == ("<", " />")
 
     def test_empty_sinfo_table(self):
-        ttree = TemplateParser.parse_to_ttree(t"<!doctype html>ABC")
+        ttree = TemplateParser.parse(t"<!doctype html>ABC")
         sinfo_table = ttree.unpack_sinfo_table()
         assert not sinfo_table

--- a/tdom/parser_utils.py
+++ b/tdom/parser_utils.py
@@ -45,7 +45,7 @@ def make_parser_pos_translator(
     )
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class ParserPositionTranslator:
     line_start_offsets: tuple[int, ...]
     """Absolute offsets where lines in the parser input start."""
@@ -86,6 +86,33 @@ class ParserPositionTranslator:
             )
         return line_start + offset
 
+    def parser_pos_to_part_pos(self, parser_pos: ParserPosition) -> PartPosition:
+        """
+        Translate an absolute parser-input position into a template part position.
+
+        A position exactly between parts belongs to the following part. EOF is the
+        exception: a template always ends with a string part, and EOF belongs to the
+        end of that final string.
+        """
+        source_length = self.part_end_offsets[-1]
+        if not 0 <= parser_pos <= source_length:
+            raise ValueError(
+                f"Parser position falls outside the input: {parser_pos} not in [0, {source_length}]"
+            )
+
+        last_index = len(self.part_end_offsets) - 1
+        if parser_pos == source_length:
+            final_part_start = (
+                self.part_end_offsets[last_index - 1] if last_index else 0
+            )
+            return PartPosition(last_index, source_length - final_part_start)
+
+        index = bisect_left(self.part_end_offsets, parser_pos)
+        part_start = self.part_end_offsets[index - 1] if index else 0
+        if parser_pos == self.part_end_offsets[index]:
+            return PartPosition(index + 1, 0)
+        return PartPosition(index, parser_pos - part_start)
+
     def translate(self, raw_parser_pos: LinePosition) -> PartPosition:
         """
         Translate a parser line position to a template part position.
@@ -101,35 +128,6 @@ class ParserPositionTranslator:
             `0` but the offset can be a non-zero number for string parts.
         """
         parser_pos = self.validate_raw_parser_pos(raw_parser_pos)
-        part_pos = parser_pos_to_part_pos(self.part_end_offsets, parser_pos)
+        part_pos = self.parser_pos_to_part_pos(parser_pos)
         validate_part_position(part_pos)
         return part_pos
-
-
-def parser_pos_to_part_pos(
-    part_end_offsets: tuple[int, ...],
-    parser_pos: ParserPosition,
-) -> PartPosition:
-    """
-    Translate an absolute parser-input position into a template part position.
-
-    A position exactly between parts belongs to the following part. EOF is the
-    exception: a template always ends with a string part, and EOF belongs to the
-    end of that final string.
-    """
-    source_length = part_end_offsets[-1]
-    if not 0 <= parser_pos <= source_length:
-        raise ValueError(
-            f"Parser position falls outside the input: {parser_pos} not in [0, {source_length}]"
-        )
-
-    last_index = len(part_end_offsets) - 1
-    if parser_pos == source_length:
-        final_part_start = part_end_offsets[last_index - 1] if last_index else 0
-        return PartPosition(last_index, source_length - final_part_start)
-
-    index = bisect_left(part_end_offsets, parser_pos)
-    part_start = part_end_offsets[index - 1] if index else 0
-    if parser_pos == part_end_offsets[index]:
-        return PartPosition(index + 1, 0)
-    return PartPosition(index, parser_pos - part_start)

--- a/tdom/parser_utils.py
+++ b/tdom/parser_utils.py
@@ -1,71 +1,25 @@
+from bisect import bisect_left
 from dataclasses import dataclass
+from itertools import accumulate
 from string.templatelib import Template
 
 from .placeholders import PlaceholderConfig
-from .source import LinePosition, MutableLinePosition
+from .source import LinePosition
 from .template_utils import PartPosition, validate_part_position
 
 type HTMLAttribute = tuple[str, str | None]
+type ParserPosition = int
+"""Absolute offset into the placeholder-expanded parser input, starting at 0."""
 
 
-@dataclass(frozen=True)
-class ParserPosition:
+def precompute_line_start_offsets(source_text: str) -> tuple[int, ...]:
     """
-    A parser position returned by the template parser.
+    Return the absolute offset where each line in the parser input starts.
 
-    In certain cases the offset points at "nothing" but has extra meaning
-    handling by flags.  These can be used when converting this position
-    to a PartPosition.
+    The first line always starts at zero. A trailing newline therefore produces
+    one final line start whose offset is also the length of the input.
     """
-
-    line: int = 1
-    " Line number, starts counting at 1. "
-
-    offset: int = 0
-    " Offset into the line, starts counting at 0. "
-
-    eol: bool = False
-    " Offset to the NL at the end of line. "
-
-    eof: bool = False
-    " Offset to the end of the input, there is no line terminator."
-
-
-def precompute_line_to_part_pos(
-    source_text_parts: tuple[str, ...],
-) -> dict[int, PartPosition]:
-    """
-    Precompute the part position of the start of every line.
-
-    @NOTE: This might be a performance improvement *but its purpose*
-    is to simplify the translation logic because we can start from a part
-    position right away by using the requested line without the offset. See the
-    `ParserPositionTranslator` for more information.
-
-    source_text_parts:
-        A tuple of all the template parts (strings and interpolations) but with
-        the interpolations converted to placeholders. These parts are in-order
-        as they are in the template using a unified indexing scheme, ie. from
-        `0` to `2 * len(template.strings) - 1`.
-
-    return:
-        A mapping from line number, starting at 1, to the part position where
-        that line starts, ie. `LinePosition(line=line, offset=0)`.
-
-    """
-    line_to_part_pos = {1: PartPosition(0, 0)}
-    line = 1
-    for index, part_text in enumerate(source_text_parts):
-        start = 0
-        while 1:
-            nl_index = part_text.find("\n", start)
-            if nl_index != -1:
-                line += 1
-                start = nl_index + 1
-                line_to_part_pos[line] = PartPosition(index, start)
-            else:
-                break
-    return line_to_part_pos
+    return (0, *(index + 1 for index, char in enumerate(source_text) if char == "\n"))
 
 
 def make_parser_pos_translator(
@@ -83,70 +37,54 @@ def make_parser_pos_translator(
         else config.make_placeholder((index - 1) // 2)
         for index in range(2 * len(template.strings) - 1)
     )
-    source_text_lines = tuple("".join(source_text_parts).split("\n"))
-
-    line_to_part_pos = precompute_line_to_part_pos(source_text_parts)
+    source_text = "".join(source_text_parts)
 
     return ParserPositionTranslator(
-        source_text_parts, source_text_lines, line_to_part_pos
+        line_start_offsets=precompute_line_start_offsets(source_text),
+        part_end_offsets=tuple(accumulate(map(len, source_text_parts))),
     )
 
 
 @dataclass
 class ParserPositionTranslator:
-    source_text_parts: tuple[str, ...]
-    " The source text of each template part, with placeholders. "
+    line_start_offsets: tuple[int, ...]
+    """Absolute offsets where lines in the parser input start."""
 
-    source_text_lines: tuple[str, ...]
-    " The source text of the entire template, with placeholders. "
-
-    line_to_part_pos: dict[int, PartPosition]
-    " Precomputed mapping from line number to part position. "
+    part_end_offsets: tuple[int, ...]
+    """Cumulative end offsets of the placeholder-expanded template parts."""
 
     def validate_raw_parser_pos(
         self,
         raw_parser_pos: LinePosition,
-        coerce_eol: bool = True,
-        coerce_eof: bool = True,
     ) -> ParserPosition:
         """
-        Check parser position targets existing line and offset in template.
+        Validate and normalize a parser line position to an absolute position.
 
-        This attempts to reduce the complexity of the translating by letting us
-        assume the translation is possible.
+        An offset equal to a non-final line's length points at its newline. An
+        offset equal to the final line's length points at EOF.
         """
         line = raw_parser_pos.line
         offset = raw_parser_pos.offset
-        if line > len(self.source_text_lines):
+        line_count = len(self.line_start_offsets)
+        if line > line_count:
             raise ValueError("Line does not exist in source.")
         elif line <= 0:
             raise ValueError("Unreachable line number, must be > 0.")
-        # either eol or eof
-        end_index = len(self.source_text_lines[line - 1])
-        last_line = len(self.source_text_lines)  # 1-based
-        eof = False
-        eol = False
         if offset < 0:
             raise ValueError("Unreachable offset, must be >= 0.")
-        elif offset == end_index and line == last_line:
-            if coerce_eof:
-                eof = True
-            else:
-                raise ValueError(
-                    f"Offset exceeds reachable characters of last line and coerce EOF is off: {line}: {offset} == {end_index}"
-                )
-        elif offset == end_index and line != last_line:
-            if coerce_eol:
-                eol = True
-            else:
-                raise ValueError(
-                    f"Offset exceeds reachable characters of line terminated with newline and coerce EOL is off: {line}: {offset} == {end_index}"
-                )
-        elif offset >= end_index:
+
+        line_start = self.line_start_offsets[line - 1]
+        line_end = (
+            self.line_start_offsets[line] - 1
+            if line < line_count
+            else self.part_end_offsets[-1]
+        )
+        line_length = line_end - line_start
+        if offset > line_length:
             raise ValueError(
-                f"Offset exceeds reachable characters of line: {line}: {offset} >= {end_index}"
+                f"Offset exceeds reachable characters of line: {line}: {offset} > {line_length}"
             )
-        return ParserPosition(line=line, offset=offset, eol=eol, eof=eof)
+        return line_start + offset
 
     def translate(self, raw_parser_pos: LinePosition) -> PartPosition:
         """
@@ -163,67 +101,36 @@ class ParserPositionTranslator:
             `0` but the offset can be a non-zero number for string parts.
         """
         parser_pos = self.validate_raw_parser_pos(raw_parser_pos)
-        part_pos = parser_pos_to_part_pos(
-            self.source_text_parts, parser_pos, self.line_to_part_pos
-        )
+        part_pos = parser_pos_to_part_pos(self.part_end_offsets, parser_pos)
         validate_part_position(part_pos)
         return part_pos
 
 
 def parser_pos_to_part_pos(
-    parts: tuple[str, ...],
+    part_end_offsets: tuple[int, ...],
     parser_pos: ParserPosition,
-    line_to_part_pos: dict[int, PartPosition],
 ) -> PartPosition:
     """
-    Translate the given parser position into a template part position.
+    Translate an absolute parser-input position into a template part position.
 
-    - Jump to the precomputed part position for the given line.
-    - Iterate over the subsequent template parts.
-    - Track the offset while advancing into each part.
-    - When we reach the parser position then return the current part
-        and the current offset from the start of that part.
+    A position exactly between parts belongs to the following part. EOF is the
+    exception: a template always ends with a string part, and EOF belongs to the
+    end of that final string.
     """
-    pos = MutableLinePosition(line=parser_pos.line, offset=0)
-    part_pos = line_to_part_pos[parser_pos.line]
-    start_text = parts[part_pos.index][part_pos.offset :]
-    last_index = len(parts) - 1
-    for index, part_text in enumerate(
-        (start_text, *parts[part_pos.index + 1 :]), start=part_pos.index
-    ):
-        # got enough lines, we just need more offset
-        first_nl_index = part_text.find("\n")
-        offset_found = (
-            len(part_text[:first_nl_index]) if first_nl_index != -1 else len(part_text)
+    absolute_offset = parser_pos
+    source_length = part_end_offsets[-1]
+    if not 0 <= absolute_offset <= source_length:
+        raise ValueError(
+            f"Parser position falls outside the input: {absolute_offset} not in [0, {source_length}]"
         )
-        offset_need = parser_pos.offset - pos.offset
-        part_offset = 0 if index != part_pos.index else part_pos.offset
-        if offset_found > offset_need:
-            pos.offset += offset_need
-            part_offset += offset_need
-            return PartPosition(index, part_offset)
-        elif offset_found == offset_need:
-            part_offset += offset_need
-            if first_nl_index == -1:
-                if index != last_index:
-                    return PartPosition(index + 1, 0)
-                elif parser_pos.eof:  # index is last_index
-                    return PartPosition(index, part_offset)
-                else:
-                    # This is the last index, a string,
-                    # and the parser position is pointing off the end.
-                    raise ValueError(
-                        "Configured parser position lands at EOF but eof is False."
-                    )
-            else:
-                if parser_pos.eol:
-                    return PartPosition(index, part_offset)
-                else:
-                    raise ValueError(
-                        "Configured parser position lands at EOL but eol is False."
-                    )
-        else:
-            pos.offset += offset_found
-    raise AssertionError(
-        f"Unexpected position {pos}, did not reach required position {parser_pos}"
-    )
+
+    last_index = len(part_end_offsets) - 1
+    if absolute_offset == source_length:
+        final_part_start = part_end_offsets[last_index - 1] if last_index else 0
+        return PartPosition(last_index, source_length - final_part_start)
+
+    index = bisect_left(part_end_offsets, absolute_offset)
+    part_start = part_end_offsets[index - 1] if index else 0
+    if absolute_offset == part_end_offsets[index]:
+        return PartPosition(index + 1, 0)
+    return PartPosition(index, absolute_offset - part_start)

--- a/tdom/parser_utils.py
+++ b/tdom/parser_utils.py
@@ -8,8 +8,8 @@ from .source import LinePosition
 from .template_utils import PartPosition, validate_part_position
 
 type HTMLAttribute = tuple[str, str | None]
-type ParserPosition = int
-"""Absolute offset into the placeholder-expanded parser input, starting at 0."""
+type AbsolutePosition = int
+"""Absolute position into the placeholder-expanded template source, starting at 0."""
 
 
 def precompute_line_start_offsets(source_text: str) -> tuple[int, ...]:
@@ -53,18 +53,18 @@ class ParserPositionTranslator:
     part_end_offsets: tuple[int, ...]
     """Cumulative end offsets of the placeholder-expanded template parts."""
 
-    def validate_raw_parser_pos(
+    def line_pos_to_abs_pos(
         self,
-        raw_parser_pos: LinePosition,
-    ) -> ParserPosition:
+        line_pos: LinePosition,
+    ) -> AbsolutePosition:
         """
         Validate and normalize a parser line position to an absolute position.
 
         An offset equal to a non-final line's length points at its newline. An
         offset equal to the final line's length points at EOF.
         """
-        line = raw_parser_pos.line
-        offset = raw_parser_pos.offset
+        line = line_pos.line
+        offset = line_pos.offset
         line_count = len(self.line_start_offsets)
         if line > line_count:
             raise ValueError("Line does not exist in source.")
@@ -86,38 +86,38 @@ class ParserPositionTranslator:
             )
         return line_start + offset
 
-    def parser_pos_to_part_pos(self, parser_pos: ParserPosition) -> PartPosition:
+    def abs_pos_to_part_pos(self, abs_pos: AbsolutePosition) -> PartPosition:
         """
-        Translate an absolute parser-input position into a template part position.
+        Translate an absolute position into a template part position.
 
         A position exactly between parts belongs to the following part. EOF is the
         exception: a template always ends with a string part, and EOF belongs to the
         end of that final string.
         """
         source_length = self.part_end_offsets[-1]
-        if not 0 <= parser_pos <= source_length:
+        if not 0 <= abs_pos <= source_length:
             raise ValueError(
-                f"Parser position falls outside the input: {parser_pos} not in [0, {source_length}]"
+                f"Absolute position falls outside the input: {abs_pos} not in [0, {source_length}]"
             )
 
         last_index = len(self.part_end_offsets) - 1
-        if parser_pos == source_length:
+        if abs_pos == source_length:
             final_part_start = (
                 self.part_end_offsets[last_index - 1] if last_index else 0
             )
             return PartPosition(last_index, source_length - final_part_start)
 
-        index = bisect_left(self.part_end_offsets, parser_pos)
+        index = bisect_left(self.part_end_offsets, abs_pos)
         part_start = self.part_end_offsets[index - 1] if index else 0
-        if parser_pos == self.part_end_offsets[index]:
+        if abs_pos == self.part_end_offsets[index]:
             return PartPosition(index + 1, 0)
-        return PartPosition(index, parser_pos - part_start)
+        return PartPosition(index, abs_pos - part_start)
 
-    def translate(self, raw_parser_pos: LinePosition) -> PartPosition:
+    def translate(self, parser_pos: LinePosition) -> PartPosition:
         """
         Translate a parser line position to a template part position.
 
-        raw_parser_pos:
+        parser_pos:
             A line position in a coordinate system that consists of the entire
             template merged into a continuous string with placeholder strings
             injected for `Interpolation`s.
@@ -127,7 +127,7 @@ class ParserPositionTranslator:
             the parts of the `Template`.  For interpolations the offset must be
             `0` but the offset can be a non-zero number for string parts.
         """
-        parser_pos = self.validate_raw_parser_pos(raw_parser_pos)
-        part_pos = self.parser_pos_to_part_pos(parser_pos)
+        abs_pos = self.line_pos_to_abs_pos(parser_pos)
+        part_pos = self.abs_pos_to_part_pos(abs_pos)
         validate_part_position(part_pos)
         return part_pos

--- a/tdom/parser_utils.py
+++ b/tdom/parser_utils.py
@@ -1,0 +1,193 @@
+from dataclasses import dataclass
+from string.templatelib import Template
+
+from .placeholders import PlaceholderConfig
+from .source import LinePosition, MutableLinePosition
+from .template_utils import PartPosition, validate_part_position
+
+type HTMLAttribute = tuple[str, str | None]
+
+
+@dataclass(frozen=True)
+class ParserPosition:
+    """
+    A parser position returned by the template parser.
+
+    In certain cases the offset points at "nothing" but has extra meaning
+    handling by flags.  These can be used when converting this position
+    to a PartPosition.
+    """
+
+    line: int = 1
+    " Line number, starts counting at 1. "
+
+    offset: int = 0
+    " Offset into the line, starts counting at 0. "
+
+    eol: bool = False
+    " Offset to the NL at the end of line. "
+
+    eof: bool = False
+    " Offset to the end of the input, there is no line terminator."
+
+
+def precompute_line_to_part_pos(
+    source_text_parts: tuple[str, ...],
+) -> dict[int, PartPosition]:
+    line_to_part_pos = {1: PartPosition(0, 0)}
+    line = 1
+    for index, part_text in enumerate(source_text_parts):
+        start = 0
+        while 1:
+            nl_index = part_text.find("\n", start)
+            if nl_index != -1:
+                line += 1
+                start = nl_index + 1
+                line_to_part_pos[line] = PartPosition(index, start)
+            else:
+                break
+    return line_to_part_pos
+
+
+def make_parser_pos_translator(
+    template: Template, config: PlaceholderConfig
+) -> ParserPositionTranslator:
+
+    source_text_parts = tuple(
+        template.strings[index // 2]
+        if index % 2 == 0
+        else config.make_placeholder((index - 1) // 2)
+        for index in range(2 * len(template.strings) - 1)
+    )
+    source_text_lines = tuple("".join(source_text_parts).split("\n"))
+
+    line_to_part_pos = precompute_line_to_part_pos(source_text_parts)
+
+    return ParserPositionTranslator(
+        source_text_parts, source_text_lines, line_to_part_pos
+    )
+
+
+@dataclass
+class ParserPositionTranslator:
+    source_text_parts: tuple[str, ...]
+    " The source text of each template part, with placeholders. "
+
+    source_text_lines: tuple[str, ...]
+    " The source text of the entire template, with placeholders. "
+
+    line_to_part_pos: dict[int, PartPosition]
+    " Precomputed mapping from line number to part position. "
+
+    def validate_raw_parser_pos(
+        self,
+        raw_parser_pos: LinePosition,
+        coerce_eol: bool = True,
+        coerce_eof: bool = True,
+    ) -> ParserPosition:
+        """
+        Check parser position targets existing line and offset in template.
+
+        This attempts to reduce the complexity of the translating by letting us
+        assume the translation is possible.
+        """
+        line = raw_parser_pos.line
+        offset = raw_parser_pos.offset
+        if line > len(self.source_text_lines):
+            raise ValueError("Line does not exist in source.")
+        elif line <= 0:
+            raise ValueError("Unreachable line number, must be > 0.")
+        # either eol or eof
+        end_index = len(self.source_text_lines[line - 1])
+        last_line = len(self.source_text_lines)  # 1-based
+        eof = False
+        eol = False
+        if offset < 0:
+            raise ValueError("Unreachable offset, must be >= 0.")
+        elif offset == end_index and line == last_line:
+            if coerce_eof:
+                eof = True
+            else:
+                raise ValueError(
+                    f"Offset exceeds reachable characters of last line and coerce EOF is off: {line}: {offset} == {end_index}"
+                )
+        elif offset == end_index and line != last_line:
+            if coerce_eol:
+                eol = True
+            else:
+                raise ValueError(
+                    f"Offset exceeds reachable characters of line terminated with newline and coerce EOL is off: {line}: {offset} == {end_index}"
+                )
+        elif offset >= end_index:
+            raise ValueError(
+                f"Offset exceeds reachable characters of line: {line}: {offset} >= {end_index}"
+            )
+        return ParserPosition(line=line, offset=offset, eol=eol, eof=eof)
+
+    def translate(self, raw_parser_pos: LinePosition) -> PartPosition:
+        parser_pos = self.validate_raw_parser_pos(raw_parser_pos)
+        part_pos = parser_pos_to_part_pos(
+            self.source_text_parts, parser_pos, self.line_to_part_pos
+        )
+        validate_part_position(part_pos)
+        return part_pos
+
+
+def parser_pos_to_part_pos(
+    parts: tuple[str, ...],
+    parser_pos: ParserPosition,
+    line_to_part_pos: dict[int, PartPosition],
+) -> PartPosition:
+    """
+    Translate the given parser position into a template part position.
+
+    - Jump to the precomputed part position for the given line.
+    - Iterate over the subsequent template parts.
+    - Track the offset while advancing into each part.
+    - When we reach the parser position then return the current part
+        and the current offset from the start of that part.
+
+    """
+    pos = MutableLinePosition(line=parser_pos.line, offset=0)
+    part_pos = line_to_part_pos[parser_pos.line]
+    start_text = parts[part_pos.index][part_pos.offset :]
+    last_index = len(parts) - 1
+    for index, part_text in enumerate(
+        (start_text, *parts[part_pos.index + 1 :]), start=part_pos.index
+    ):
+        # got enough lines, we just need more offset
+        first_nl_index = part_text.find("\n")
+        offset_found = (
+            len(part_text[:first_nl_index]) if first_nl_index != -1 else len(part_text)
+        )
+        offset_need = parser_pos.offset - pos.offset
+        part_offset = 0 if index != part_pos.index else part_pos.offset
+        if offset_found > offset_need:
+            pos.offset += offset_need
+            part_offset += offset_need
+            return PartPosition(index, part_offset)
+        elif offset_found == offset_need:
+            part_offset += offset_need
+            if first_nl_index == -1:
+                if index != last_index:
+                    return PartPosition(index + 1, 0)
+                elif parser_pos.eof:  # index is last_index
+                    return PartPosition(index, part_offset)
+                else:
+                    # This is the last index, a string,
+                    # and the parser position is pointing off the end.
+                    raise ValueError(
+                        "Configured parser position lands at EOF but eof is False."
+                    )
+            else:
+                if parser_pos.eol:
+                    return PartPosition(index, part_offset)
+                else:
+                    raise ValueError(
+                        "Configured parser position lands at EOL but eol is False."
+                    )
+        else:
+            pos.offset += offset_found
+    raise AssertionError(
+        f"Unexpected position {pos}, did not reach required position {parser_pos}"
+    )

--- a/tdom/parser_utils.py
+++ b/tdom/parser_utils.py
@@ -9,15 +9,15 @@ from .template_utils import PartPosition, validate_part_position
 
 type HTMLAttribute = tuple[str, str | None]
 type AbsolutePosition = int
-"""Absolute position into the placeholder-expanded template source, starting at 0."""
+"""Absolute position in the placeholder-expanded template source, starting at 0."""
 
 
-def precompute_line_start_offsets(source_text: str) -> tuple[int, ...]:
+def precompute_line_start_positions(source_text: str) -> tuple[AbsolutePosition, ...]:
     """
-    Return the absolute offset where each line in the parser input starts.
+    Return the absolute positions where each line in the parser input starts.
 
     The first line always starts at zero. A trailing newline therefore produces
-    one final line start whose offset is also the length of the input.
+    one final line start whose absolute position is also the length of the input.
     """
     return (0, *(index + 1 for index, char in enumerate(source_text) if char == "\n"))
 
@@ -40,18 +40,18 @@ def make_parser_pos_translator(
     source_text = "".join(source_text_parts)
 
     return ParserPositionTranslator(
-        line_start_offsets=precompute_line_start_offsets(source_text),
-        part_end_offsets=tuple(accumulate(map(len, source_text_parts))),
+        line_start_positions=precompute_line_start_positions(source_text),
+        part_end_positions=tuple(accumulate(map(len, source_text_parts))),
     )
 
 
 @dataclass(frozen=True, slots=True)
 class ParserPositionTranslator:
-    line_start_offsets: tuple[int, ...]
-    """Absolute offsets where lines in the parser input start."""
+    line_start_positions: tuple[AbsolutePosition, ...]
+    """Absolute positions where lines in the parser input start."""
 
-    part_end_offsets: tuple[int, ...]
-    """Cumulative end offsets of the placeholder-expanded template parts."""
+    part_end_positions: tuple[AbsolutePosition, ...]
+    """Absolute positions where placeholder-expanded template parts end."""
 
     def line_pos_to_abs_pos(
         self,
@@ -65,7 +65,7 @@ class ParserPositionTranslator:
         """
         line = line_pos.line
         offset = line_pos.offset
-        line_count = len(self.line_start_offsets)
+        line_count = len(self.line_start_positions)
         if line > line_count:
             raise ValueError("Line does not exist in source.")
         elif line <= 0:
@@ -73,11 +73,11 @@ class ParserPositionTranslator:
         if offset < 0:
             raise ValueError("Unreachable offset, must be >= 0.")
 
-        line_start = self.line_start_offsets[line - 1]
+        line_start = self.line_start_positions[line - 1]
         line_end = (
-            self.line_start_offsets[line] - 1
+            self.line_start_positions[line] - 1
             if line < line_count
-            else self.part_end_offsets[-1]
+            else self.part_end_positions[-1]
         )
         line_length = line_end - line_start
         if offset > line_length:
@@ -94,22 +94,22 @@ class ParserPositionTranslator:
         exception: a template always ends with a string part, and EOF belongs to the
         end of that final string.
         """
-        source_length = self.part_end_offsets[-1]
+        source_length = self.part_end_positions[-1]
         if not 0 <= abs_pos <= source_length:
             raise ValueError(
                 f"Absolute position falls outside the input: {abs_pos} not in [0, {source_length}]"
             )
 
-        last_index = len(self.part_end_offsets) - 1
+        last_index = len(self.part_end_positions) - 1
         if abs_pos == source_length:
             final_part_start = (
-                self.part_end_offsets[last_index - 1] if last_index else 0
+                self.part_end_positions[last_index - 1] if last_index else 0
             )
             return PartPosition(last_index, source_length - final_part_start)
 
-        index = bisect_left(self.part_end_offsets, abs_pos)
-        part_start = self.part_end_offsets[index - 1] if index else 0
-        if abs_pos == self.part_end_offsets[index]:
+        index = bisect_left(self.part_end_positions, abs_pos)
+        part_start = self.part_end_positions[index - 1] if index else 0
+        if abs_pos == self.part_end_positions[index]:
             return PartPosition(index + 1, 0)
         return PartPosition(index, abs_pos - part_start)
 

--- a/tdom/parser_utils.py
+++ b/tdom/parser_utils.py
@@ -117,20 +117,19 @@ def parser_pos_to_part_pos(
     exception: a template always ends with a string part, and EOF belongs to the
     end of that final string.
     """
-    absolute_offset = parser_pos
     source_length = part_end_offsets[-1]
-    if not 0 <= absolute_offset <= source_length:
+    if not 0 <= parser_pos <= source_length:
         raise ValueError(
-            f"Parser position falls outside the input: {absolute_offset} not in [0, {source_length}]"
+            f"Parser position falls outside the input: {parser_pos} not in [0, {source_length}]"
         )
 
     last_index = len(part_end_offsets) - 1
-    if absolute_offset == source_length:
+    if parser_pos == source_length:
         final_part_start = part_end_offsets[last_index - 1] if last_index else 0
         return PartPosition(last_index, source_length - final_part_start)
 
-    index = bisect_left(part_end_offsets, absolute_offset)
+    index = bisect_left(part_end_offsets, parser_pos)
     part_start = part_end_offsets[index - 1] if index else 0
-    if absolute_offset == part_end_offsets[index]:
+    if parser_pos == part_end_offsets[index]:
         return PartPosition(index + 1, 0)
-    return PartPosition(index, absolute_offset - part_start)
+    return PartPosition(index, parser_pos - part_start)

--- a/tdom/parser_utils.py
+++ b/tdom/parser_utils.py
@@ -34,6 +34,25 @@ class ParserPosition:
 def precompute_line_to_part_pos(
     source_text_parts: tuple[str, ...],
 ) -> dict[int, PartPosition]:
+    """
+    Precompute the part position of the start of every line.
+
+    @NOTE: This might be a performance improvement *but its purpose*
+    is to simplify the translation logic because we can start from a part
+    position right away by using the requested line without the offset. See the
+    `ParserPositionTranslator` for more information.
+
+    source_text_parts:
+        A tuple of all the template parts (strings and interpolations) but with
+        the interpolations converted to placeholders. These parts are in-order
+        as they are in the template using a unified indexing scheme, ie. from
+        `0` to `2 * len(template.strings) - 1`.
+
+    return:
+        A mapping from line number, starting at 1, to the part position where
+        that line starts, ie. `LinePosition(line=line, offset=0)`.
+
+    """
     line_to_part_pos = {1: PartPosition(0, 0)}
     line = 1
     for index, part_text in enumerate(source_text_parts):
@@ -52,6 +71,11 @@ def precompute_line_to_part_pos(
 def make_parser_pos_translator(
     template: Template, config: PlaceholderConfig
 ) -> ParserPositionTranslator:
+    """
+    Configure and return a `ParserPositionTranslator`.
+
+    We precompute a few things to make the translator's job easier.
+    """
 
     source_text_parts = tuple(
         template.strings[index // 2]
@@ -125,6 +149,19 @@ class ParserPositionTranslator:
         return ParserPosition(line=line, offset=offset, eol=eol, eof=eof)
 
     def translate(self, raw_parser_pos: LinePosition) -> PartPosition:
+        """
+        Translate a parser line position to a template part position.
+
+        raw_parser_pos:
+            A line position in a coordinate system that consists of the entire
+            template merged into a continuous string with placeholder strings
+            injected for `Interpolation`s.
+
+        return:
+            A position in a coordinate system that uses a unified index into
+            the parts of the `Template`.  For interpolations the offset must be
+            `0` but the offset can be a non-zero number for string parts.
+        """
         parser_pos = self.validate_raw_parser_pos(raw_parser_pos)
         part_pos = parser_pos_to_part_pos(
             self.source_text_parts, parser_pos, self.line_to_part_pos
@@ -146,7 +183,6 @@ def parser_pos_to_part_pos(
     - Track the offset while advancing into each part.
     - When we reach the parser position then return the current part
         and the current offset from the start of that part.
-
     """
     pos = MutableLinePosition(line=parser_pos.line, offset=0)
     part_pos = line_to_part_pos[parser_pos.line]

--- a/tdom/parser_utils_test.py
+++ b/tdom/parser_utils_test.py
@@ -31,6 +31,20 @@ class TestParserPositionTranslator:
         assert ppt.validate_raw_parser_pos(LinePosition(2, 2)) == 5
         assert ppt.validate_raw_parser_pos(LinePosition(3, 0)) == 6
 
+    def test_translate_absolute_offset_to_part_position(self, ph_config):
+        ppt = make_ppt(t"a{0}b", ph_config)
+        placeholder_length = len(ph_config.make_placeholder(0))
+
+        assert ppt.parser_pos_to_part_pos(0) == PartPosition(0, 0)
+        assert ppt.parser_pos_to_part_pos(1) == PartPosition(1, 0)
+        assert ppt.parser_pos_to_part_pos(1 + placeholder_length) == PartPosition(2, 0)
+        assert ppt.parser_pos_to_part_pos(2 + placeholder_length) == PartPosition(2, 1)
+
+        with pytest.raises(ValueError, match="Parser position falls outside"):
+            ppt.parser_pos_to_part_pos(-1)
+        with pytest.raises(ValueError, match="Parser position falls outside"):
+            ppt.parser_pos_to_part_pos(3 + placeholder_length)
+
     def test_case_nontailing_string_ends_with_newline(self, ph_config):
         ppt = make_ppt(t"a\n{0}b", ph_config)
         assert ppt.translate(LinePosition(line=2, offset=0)) == PartPosition(

--- a/tdom/parser_utils_test.py
+++ b/tdom/parser_utils_test.py
@@ -22,28 +22,28 @@ def make_ppt(template: Template, config: PlaceholderConfig) -> ParserPositionTra
 
 
 class TestParserPositionTranslator:
-    def test_normalize_to_absolute_offset(self, ph_config):
+    def test_line_pos_to_abs_pos(self, ph_config):
         ppt = make_ppt(t"ab\ncd\n", ph_config)
 
-        assert ppt.validate_raw_parser_pos(LinePosition(1, 0)) == 0
-        assert ppt.validate_raw_parser_pos(LinePosition(1, 2)) == 2
-        assert ppt.validate_raw_parser_pos(LinePosition(2, 0)) == 3
-        assert ppt.validate_raw_parser_pos(LinePosition(2, 2)) == 5
-        assert ppt.validate_raw_parser_pos(LinePosition(3, 0)) == 6
+        assert ppt.line_pos_to_abs_pos(LinePosition(1, 0)) == 0
+        assert ppt.line_pos_to_abs_pos(LinePosition(1, 2)) == 2
+        assert ppt.line_pos_to_abs_pos(LinePosition(2, 0)) == 3
+        assert ppt.line_pos_to_abs_pos(LinePosition(2, 2)) == 5
+        assert ppt.line_pos_to_abs_pos(LinePosition(3, 0)) == 6
 
-    def test_translate_absolute_offset_to_part_position(self, ph_config):
+    def test_translate_abs_pos_to_part_pos(self, ph_config):
         ppt = make_ppt(t"a{0}b", ph_config)
         placeholder_length = len(ph_config.make_placeholder(0))
 
-        assert ppt.parser_pos_to_part_pos(0) == PartPosition(0, 0)
-        assert ppt.parser_pos_to_part_pos(1) == PartPosition(1, 0)
-        assert ppt.parser_pos_to_part_pos(1 + placeholder_length) == PartPosition(2, 0)
-        assert ppt.parser_pos_to_part_pos(2 + placeholder_length) == PartPosition(2, 1)
+        assert ppt.abs_pos_to_part_pos(0) == PartPosition(0, 0)
+        assert ppt.abs_pos_to_part_pos(1) == PartPosition(1, 0)
+        assert ppt.abs_pos_to_part_pos(1 + placeholder_length) == PartPosition(2, 0)
+        assert ppt.abs_pos_to_part_pos(2 + placeholder_length) == PartPosition(2, 1)
 
-        with pytest.raises(ValueError, match="Parser position falls outside"):
-            ppt.parser_pos_to_part_pos(-1)
-        with pytest.raises(ValueError, match="Parser position falls outside"):
-            ppt.parser_pos_to_part_pos(3 + placeholder_length)
+        with pytest.raises(ValueError, match="Absolute position falls outside"):
+            ppt.abs_pos_to_part_pos(-1)
+        with pytest.raises(ValueError, match="Absolute position falls outside"):
+            ppt.abs_pos_to_part_pos(3 + placeholder_length)
 
     def test_case_nontailing_string_ends_with_newline(self, ph_config):
         ppt = make_ppt(t"a\n{0}b", ph_config)

--- a/tdom/parser_utils_test.py
+++ b/tdom/parser_utils_test.py
@@ -1,0 +1,165 @@
+from string.templatelib import Template
+
+import pytest
+
+from .parser_utils import ParserPositionTranslator, make_parser_pos_translator
+from .placeholders import PlaceholderConfig, make_placeholder_config
+from .source import LinePosition
+from .template_utils import PartPosition
+
+
+@pytest.fixture(scope="module")
+def ph_config():
+    return make_placeholder_config()
+
+
+def make_ppt(template: Template, config: PlaceholderConfig) -> ParserPositionTranslator:
+    "Just a shorthand function."
+    return make_parser_pos_translator(template=template, config=config)
+
+
+class TestParserPositionTranslator:
+    def test_case_nontailing_string_ends_with_newline(self, ph_config):
+        ppt = make_ppt(t"a\n{0}b", ph_config)
+        assert ppt.translate(LinePosition(line=2, offset=0)) == PartPosition(
+            index=1, offset=0
+        ), """This could also be considered PartPosition(index=1, offset=0)
+        but either way should work. """
+        assert ppt.translate(
+            LinePosition(line=2, offset=len(ph_config.make_placeholder(0)))
+        ) == PartPosition(
+            index=2, offset=0
+        ), """This must be the start of the following string because we can't
+        know the offset of the actual interpolation content. Ie. It cannot be
+        index=1 with "some" offset."""
+
+    def test_case_tailing_string_starts_with_newline(self, ph_config):
+        ppt = make_ppt(t"a{0}\nb", ph_config)
+        assert ppt.translate(LinePosition(line=2, offset=0)) == PartPosition(
+            index=2, offset=1
+        ), "line 2 should be inside the tailing string"
+        assert ppt.translate(
+            LinePosition(line=1, offset=1 + len(ph_config.make_placeholder(0)))
+        ) == PartPosition(index=2, offset=0), (
+            "end of line 1 should be inside the tailing string?"
+        )
+
+    def test_case_interpolation_without_lines(self, ph_config):
+        ppt = make_ppt(t"a{0}b", ph_config)
+        assert ppt.translate(LinePosition(line=1, offset=1)) == PartPosition(
+            index=1, offset=0
+        ), "end of the head string is the start of the interpolation"
+        assert ppt.translate(
+            LinePosition(line=1, offset=1 + len(ph_config.make_placeholder(0)))
+        ) == PartPosition(index=2, offset=0), (
+            "the end of the interpolation is the start of the tailing string"
+        )
+        assert ppt.translate(
+            LinePosition(line=1, offset=1 + len(ph_config.make_placeholder(0)) + 1)
+        ) == PartPosition(index=2, offset=1), (
+            "the end of the tailing string remains the end."
+        )
+
+    def test_offset_without_line(self, ph_config):
+        ppt = make_ppt(t"a*", ph_config)
+        assert ppt.translate(LinePosition(line=1, offset=1)) == PartPosition(
+            index=0, offset=1
+        ), "the offset matches up without lines"
+        assert ppt.translate(LinePosition(line=1, offset=2)) == PartPosition(
+            index=0, offset=2
+        ), "end of line is end of string"
+        with pytest.raises(ValueError, match="Offset exceeds reachable"):
+            # only 0, 1 and 2 are valid offsets for line 1
+            _ = ppt.translate(LinePosition(line=1, offset=3)) == PartPosition(
+                index=0, offset=3
+            )
+
+    def test_offset_with_line(self, ph_config):
+        ppt = make_ppt(t"ab\n*", ph_config)
+        assert ppt.translate(LinePosition(line=2, offset=0)) == PartPosition(
+            index=0, offset=3
+        ), "2nd line starts at offset in the head string"
+        assert ppt.translate(LinePosition(line=1, offset=2)) == PartPosition(
+            index=0, offset=2
+        ), "end of 1st line is offset to NL"
+        with pytest.raises(ValueError, match="Offset exceeds reachable"):
+            # only 0, 1 and 2 are valid offsets for line 1
+            _ = ppt.translate(LinePosition(line=1, offset=3))
+
+    def test_offset_with_line_in_middle_part(self, ph_config):
+        ppt = make_ppt(t"a\nb{0}cd\ne{1}\nfe", ph_config)
+        assert ppt.translate(
+            LinePosition(line=2, offset=1 + len(ph_config.make_placeholder(0)) + 2)
+        ) == PartPosition(index=2, offset=2)
+
+    def test_empty_strings(self, ph_config):
+        ppt = make_ppt(t"{0}", ph_config)
+        assert ppt.translate(LinePosition(line=1, offset=0)) == PartPosition(
+            index=1, offset=0
+        ), "start of head string is start of interpolation"
+        assert ppt.translate(
+            LinePosition(line=1, offset=len(ph_config.make_placeholder(0)))
+        ) == PartPosition(index=2, offset=0), (
+            "end of interpolation is start of tail string"
+        )
+        with pytest.raises(ValueError, match="Offset exceeds reachable"):
+            # Cannot go past end of the template.
+            _ = ppt.translate(
+                LinePosition(line=1, offset=len(ph_config.make_placeholder(0)) + 1)
+            )
+
+    def test_empty_string(self, ph_config):
+        ppt = make_ppt(t"", ph_config)
+        assert ppt.translate(LinePosition(line=1, offset=0)) == PartPosition(
+            index=0, offset=0
+        )
+        with pytest.raises(ValueError, match="Offset exceeds reachable"):
+            # Cannot go past end of the template.
+            _ = ppt.translate(LinePosition(line=1, offset=1))
+
+    def test_empty_line(self, ph_config):
+        ppt = make_ppt(t"\n", ph_config)
+        assert ppt.translate(LinePosition(line=1, offset=0)) == PartPosition(
+            index=0, offset=0
+        )
+        with pytest.raises(ValueError, match="Offset exceeds reachable"):
+            # line 1 is empty, cannot offset anything
+            _ = ppt.translate(LinePosition(line=1, offset=1))
+        assert ppt.translate(LinePosition(line=2, offset=0)) == PartPosition(
+            index=0, offset=1
+        ), "To skip over empty line just skip over newline"
+        with pytest.raises(ValueError, match="Offset exceeds reachable"):
+            # line 2 is empty, cannot offset anything
+            _ = ppt.translate(LinePosition(line=2, offset=1))
+
+    def test_bad_parser_pos_check_bounds(self, ph_config):
+        ppt = make_ppt(t"abc\ndef", ph_config)
+
+        with pytest.raises(ValueError, match="Line does not exist"):
+            _ = ppt.translate(LinePosition(line=3, offset=0))
+        with pytest.raises(ValueError, match="Unreachable line number"):
+            _ = ppt.translate(LinePosition(line=0, offset=0))
+        with pytest.raises(ValueError, match="Unreachable offset"):
+            _ = ppt.translate(LinePosition(line=1, offset=-1))
+        with pytest.raises(ValueError, match="Unreachable offset"):
+            _ = ppt.translate(LinePosition(line=2, offset=-1))
+        with pytest.raises(ValueError, match="Offset exceeds reachable"):
+            _ = ppt.translate(LinePosition(line=1, offset=100))
+        with pytest.raises(ValueError, match="Offset exceeds reachable"):
+            _ = ppt.translate(LinePosition(line=2, offset=100))
+
+    def test_bad_parser_pos_cannot_offset_interpolation(self, ph_config):
+        ppt = make_ppt(t"abc\n{0}def", ph_config)
+
+        with pytest.raises(
+            ValueError,
+            match="Invalid part position, interpolations are not divisible, offset must be 0.",
+        ):
+            _ = ppt.translate(LinePosition(line=2, offset=1))
+        with pytest.raises(
+            ValueError,
+            match="Invalid part position, interpolations are not divisible, offset must be 0.",
+        ):
+            _ = ppt.translate(
+                LinePosition(line=2, offset=len(ph_config.make_placeholder(0)) - 1)
+            )

--- a/tdom/parser_utils_test.py
+++ b/tdom/parser_utils_test.py
@@ -2,7 +2,10 @@ from string.templatelib import Template
 
 import pytest
 
-from .parser_utils import ParserPositionTranslator, make_parser_pos_translator
+from .parser_utils import (
+    ParserPositionTranslator,
+    make_parser_pos_translator,
+)
 from .placeholders import PlaceholderConfig, make_placeholder_config
 from .source import LinePosition
 from .template_utils import PartPosition
@@ -19,6 +22,15 @@ def make_ppt(template: Template, config: PlaceholderConfig) -> ParserPositionTra
 
 
 class TestParserPositionTranslator:
+    def test_normalize_to_absolute_offset(self, ph_config):
+        ppt = make_ppt(t"ab\ncd\n", ph_config)
+
+        assert ppt.validate_raw_parser_pos(LinePosition(1, 0)) == 0
+        assert ppt.validate_raw_parser_pos(LinePosition(1, 2)) == 2
+        assert ppt.validate_raw_parser_pos(LinePosition(2, 0)) == 3
+        assert ppt.validate_raw_parser_pos(LinePosition(2, 2)) == 5
+        assert ppt.validate_raw_parser_pos(LinePosition(3, 0)) == 6
+
     def test_case_nontailing_string_ends_with_newline(self, ph_config):
         ppt = make_ppt(t"a\n{0}b", ph_config)
         assert ppt.translate(LinePosition(line=2, offset=0)) == PartPosition(
@@ -58,6 +70,16 @@ class TestParserPositionTranslator:
             LinePosition(line=1, offset=1 + len(ph_config.make_placeholder(0)) + 1)
         ) == PartPosition(index=2, offset=1), (
             "the end of the tailing string remains the end."
+        )
+
+    def test_case_consecutive_interpolations(self, ph_config):
+        ppt = make_ppt(t"{0}{1}", ph_config)
+        placeholder_length = len(ph_config.make_placeholder(0))
+
+        assert ppt.translate(LinePosition(1, 0)) == PartPosition(1, 0)
+        assert ppt.translate(LinePosition(1, placeholder_length)) == PartPosition(2, 0)
+        assert ppt.translate(LinePosition(1, 2 * placeholder_length)) == PartPosition(
+            4, 0
         )
 
     def test_offset_without_line(self, ph_config):

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -29,10 +29,8 @@ from .htmlspec import (
     SVG_TAG_FIX,
     VOID_ELEMENTS,
 )
-from .parser import (
-    HTMLAttribute,
-    TemplateParser,
-)
+from .parser import TemplateParser
+from .parser_utils import HTMLAttribute
 from .protocols import HasHTMLDunder
 from .scope import ScopedTemplate
 from .template_utils import TemplateRef
@@ -49,6 +47,7 @@ from .tnodes import (
     TSpreadAttribute,
     TTemplatedAttribute,
     TText,
+    TTree,
 )
 from .utils import CachableTemplate, LastUpdatedOrderedDict
 
@@ -525,22 +524,33 @@ type RawTextInexactInterpolationValue = (
 
 class ITemplateParserProxy(t.Protocol):
     def to_tnode(self, template: Template) -> TNode: ...
+    def to_ttree(self, template: Template) -> TTree: ...
 
 
 @dataclass(frozen=True)
 class TemplateParserProxy(ITemplateParserProxy):
-    def to_tnode(self, template: Template) -> TNode:
+    def to_tnode(self, template: Template) -> TNode:  # BWC
         return TemplateParser.parse(template)
+
+    def to_ttree(self, template: Template) -> TTree:
+        return TemplateParser.parse_to_ttree(template)
 
 
 @dataclass(frozen=True)
 class CachedTemplateParserProxy(TemplateParserProxy):
     @lru_cache(512)  # noqa: B019
-    def _to_tnode(self, ct: CachableTemplate) -> TNode:
+    def _to_tnode(self, ct: CachableTemplate) -> TNode:  # BWC
         return super().to_tnode(ct.template)
 
-    def to_tnode(self, template: Template) -> TNode:
+    def to_tnode(self, template: Template) -> TNode:  # BWC
         return self._to_tnode(CachableTemplate(template))
+
+    @lru_cache(512)  # noqa: B019
+    def _to_ttree(self, ct: CachableTemplate) -> TTree:
+        return super().to_ttree(ct.template)
+
+    def to_ttree(self, template: Template) -> TTree:
+        return self._to_ttree(CachableTemplate(template))
 
 
 class IComponentProcessor(t.Protocol):
@@ -669,8 +679,8 @@ class TemplateProcessor(ITemplateProcessor):
         return self._process_template(root_template, assume_ctx)
 
     def _process_template(self, template: Template, last_ctx: ProcessContext) -> str:
-        root = self.parser_api.to_tnode(template)
-        return self._process_tnode(template, last_ctx, root)
+        ttree = self.parser_api.to_ttree(template)
+        return self._process_tnode(template, last_ctx, ttree.root)
 
     def _process_tnode(
         self, template: Template, last_ctx: ProcessContext, tnode: TNode

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -529,7 +529,7 @@ class ITemplateParserProxy(t.Protocol):
 @dataclass(frozen=True)
 class TemplateParserProxy(ITemplateParserProxy):
     def to_ttree(self, template: Template) -> TTree:
-        return TemplateParser.parse_to_ttree(template)
+        return TemplateParser.parse(template)
 
 
 @dataclass(frozen=True)

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -523,28 +523,17 @@ type RawTextInexactInterpolationValue = (
 
 
 class ITemplateParserProxy(t.Protocol):
-    def to_tnode(self, template: Template) -> TNode: ...
     def to_ttree(self, template: Template) -> TTree: ...
 
 
 @dataclass(frozen=True)
 class TemplateParserProxy(ITemplateParserProxy):
-    def to_tnode(self, template: Template) -> TNode:  # BWC
-        return TemplateParser.parse(template)
-
     def to_ttree(self, template: Template) -> TTree:
         return TemplateParser.parse_to_ttree(template)
 
 
 @dataclass(frozen=True)
 class CachedTemplateParserProxy(TemplateParserProxy):
-    @lru_cache(512)  # noqa: B019
-    def _to_tnode(self, ct: CachableTemplate) -> TNode:  # BWC
-        return super().to_tnode(ct.template)
-
-    def to_tnode(self, template: Template) -> TNode:  # BWC
-        return self._to_tnode(CachableTemplate(template))
-
     @lru_cache(512)  # noqa: B019
     def _to_ttree(self, ct: CachableTemplate) -> TTree:
         return super().to_ttree(ct.template)

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -1932,12 +1932,12 @@ def test_process_template_internal_cache():
     # this is not great and hopefully we can find a better solution.
     assert isinstance(cached_process_api, TemplateProcessor)
     assert isinstance(cached_process_api.parser_api, CachedTemplateParserProxy)
-    start_ci = cached_process_api.parser_api._to_tnode.cache_info()
-    tnode1 = process_api.parser_api.to_tnode(sample_t)
-    tnode2 = process_api.parser_api.to_tnode(sample_t)
-    cached_tnode1 = cached_process_api.parser_api.to_tnode(sample_t)
-    cached_tnode2 = cached_process_api.parser_api.to_tnode(sample_t)
-    cached_tnode3 = cached_process_api.parser_api.to_tnode(sample_diff_t)
+    start_ci = cached_process_api.parser_api._to_ttree.cache_info()
+    tnode1 = process_api.parser_api.to_ttree(sample_t).root
+    tnode2 = process_api.parser_api.to_ttree(sample_t).root
+    cached_tnode1 = cached_process_api.parser_api.to_ttree(sample_t).root
+    cached_tnode2 = cached_process_api.parser_api.to_ttree(sample_t).root
+    cached_tnode3 = cached_process_api.parser_api.to_ttree(sample_diff_t).root
     # Check that the uncached and cached services are actually
     # returning non-identical results.
     assert tnode1 is not cached_tnode1
@@ -1955,12 +1955,12 @@ def test_process_template_internal_cache():
     assert tnode2 == cached_tnode1
     # Now that we are setup we check that the cache is internally
     # working as we intended.
-    ci = cached_process_api.parser_api._to_tnode.cache_info()
+    ci = cached_process_api.parser_api._to_ttree.cache_info()
     # cached_tnode2 and cached_tnode3 are hits after cached_tnode1
     assert ci.hits - start_ci.hits == 2
     # cached_tf1 was a miss because cache was empty (brand new)
     assert ci.misses - start_ci.misses == 1
-    cached_tnode4 = cached_process_api.parser_api.to_tnode(alt_t)
+    cached_tnode4 = cached_process_api.parser_api.to_ttree(alt_t).root
     # A different template produces a brand new tf.
     assert cached_tnode1 is not cached_tnode4
     # The template is new AND has a different structure so it also

--- a/tdom/source.py
+++ b/tdom/source.py
@@ -9,17 +9,3 @@ class LinePosition:
     " Line of code, starts at 1. "
     offset: int = 0
     " Offset from the start of the line, starts at 0. "
-
-
-@dataclass(slots=True)
-class MutableLinePosition:
-    "A mutable position in a block of source code."
-
-    line: int = 1
-    " Line of code, starts at 1. "
-    offset: int = 0
-    " Offset from the start of the line, starts at 0. "
-
-    def freeze(self) -> LinePosition:
-        "Freeze ourself into an immutable object with the same values."
-        return LinePosition(line=self.line, offset=self.offset)

--- a/tdom/source.py
+++ b/tdom/source.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+
+
+@dataclass(slots=True, frozen=True)
+class LinePosition:
+    "A immutable position in a block of source code."
+
+    line: int = 1
+    " Line of code, starts at 1. "
+    offset: int = 0
+    " Offset from the start of the line, starts at 0. "
+
+
+@dataclass(slots=True)
+class MutableLinePosition:
+    "A mutable position in a block of source code."
+
+    line: int = 1
+    " Line of code, starts at 1. "
+    offset: int = 0
+    " Offset from the start of the line, starts at 0. "
+
+    def freeze(self) -> LinePosition:
+        "Freeze ourself into an immutable object with the same values."
+        return LinePosition(line=self.line, offset=self.offset)

--- a/tdom/template_utils.py
+++ b/tdom/template_utils.py
@@ -91,3 +91,45 @@ class TemplateRef:
         """Use the given interpolations to resolve this reference template into a Template."""
         resolved = [interpolations[i_index] for i_index in self.i_indexes]
         return template_from_parts(self.strings, resolved)
+
+
+@dataclass(slots=True, frozen=True)
+class PartPosition:
+    """
+    A unified template part position.
+
+    Translate indexes into strings by multiplying by 2.
+    ie. 0->0, 1->2, 2->4, etc.
+    Reverse by dividing by 2.
+
+    Translate indexes into interpolations by multiplying by 2 and then adding 1.
+    ie. 0->1, 1->3, 2->5, etc.
+    Reverse by subtracting 1 and dividing by 2.
+
+    Using unified indexes allows for simpler iteration as well as starting
+    or stopping at either type of part more seamlessly.
+    """
+
+    index: int
+    " Index of the template parts, translate for strings/interpolations. "
+
+    offset: int = 0
+    " Offset from the start of the template part. "
+
+
+def validate_part_position(part_pos: PartPosition) -> None:
+    """
+    Basic part position validation for parts that are converted to template
+    source `LinePosition`.
+
+    @TODO: This might move into the constructor eventually depending on usage.
+    """
+    if part_pos.index % 2 != 0 and part_pos.offset != 0:
+        # You can only land on the start of an interpolation
+        raise ValueError(
+            "Invalid part position, interpolations are not divisible, offset must be 0."
+        )
+    if not (part_pos.offset >= 0):
+        raise ValueError("Offset must always be positive or zero.")
+    if not (part_pos.index >= 0):
+        raise ValueError("Index must always be positive or zero.")

--- a/tdom/tnodes.py
+++ b/tdom/tnodes.py
@@ -1,7 +1,7 @@
 import typing as t
 from dataclasses import dataclass, field
 
-from .template_utils import TemplateRef
+from .template_utils import PartPosition, TemplateRef
 
 
 @dataclass(slots=True, frozen=True)
@@ -45,6 +45,8 @@ class TNode:
 class TText(TNode):
     ref: TemplateRef
 
+    source_pos: PartPosition | None = field(default=None, compare=False)
+
     @classmethod
     def empty(cls) -> t.Self:
         return cls(TemplateRef.empty())
@@ -58,6 +60,8 @@ class TText(TNode):
 class TComment(TNode):
     ref: TemplateRef
 
+    source_pos: PartPosition | None = field(default=None, compare=False)
+
     @classmethod
     def literal(cls, text: str) -> t.Self:
         return cls(TemplateRef.literal(text))
@@ -67,10 +71,14 @@ class TComment(TNode):
 class TDocumentType(TNode):
     text: str
 
+    source_pos: PartPosition | None = field(default=None, compare=False)
+
 
 @dataclass(slots=True, frozen=True)
 class TFragment(TNode):
     children: tuple[TNode, ...] = field(default_factory=tuple)
+
+    source_pos: PartPosition | None = field(default=None, compare=False)
 
 
 @dataclass(slots=True, frozen=True)
@@ -78,6 +86,8 @@ class TElement(TNode):
     tag: str
     attrs: tuple[TAttribute, ...] = field(default_factory=tuple)
     children: tuple[TNode, ...] = field(default_factory=tuple)
+
+    source_pos: PartPosition | None = field(default=None, compare=False)
 
 
 @dataclass(slots=True, frozen=True)
@@ -94,6 +104,37 @@ class TComponent(TNode):
     """The template ref that describes the component's children template."""
 
     attrs: tuple[TAttribute, ...] = field(default_factory=tuple)
+
+    source_pos: PartPosition | None = field(default=None, compare=False)
+
+
+@dataclass(frozen=True, slots=True)
+class TagSourceInfo:
+    """
+    Retained tag information from the parsed source meant for error reporting.
+
+    @NOTE: This must be cacheable so it should not directly reference a
+    template instance.
+    """
+
+    starttag_ref: TemplateRef
+    " Entire starttag as parsed except placeholders are replaced by references. "
+    startend: bool
+    " Was parsed as startend tag, ie. <tag />. "
+    starttag_pos: PartPosition
+    " Template part position of the starttag, ie. <tag> or <tag />. "
+    endtag_pos: PartPosition | None = None
+    " Template part position of the endtag, ie. </tag>. "
+
+
+@dataclass
+class TTree:
+    root: TNode
+
+    sinfos: tuple[TagSourceInfo, ...] = ()
+
+    def unpack_sinfo_table(self) -> dict[PartPosition, TagSourceInfo]:
+        return {sinfo.starttag_pos: sinfo for sinfo in self.sinfos}
 
 
 type TTag = TElement | TComponent | TFragment

--- a/tdom/tnodes.py
+++ b/tdom/tnodes.py
@@ -127,7 +127,7 @@ class TagSourceInfo:
     " Template part position of the endtag, ie. </tag>. "
 
 
-@dataclass
+@dataclass(slots=True, frozen=True)
 class TTree:
     root: TNode
 


### PR DESCRIPTION
## Design Notes

Goals
- don't overload the cache (and don't make the current cache incompatible)
- don't add a bunch of info to the core apis that we have to work around
- allow the tracking to be disabled (potentially)

#### Translation

`(template_part_index, offset_in_template_part) = translate(parser_line_number, offset_in_parser_line)`

The underlying `HTMLParser` provides a line position via `getpos()` that is relative to the entire template flattened into a continuous string with interpolations replaced with placeholders.  That line position is translated to a "part" position in the `Template` using unified indexing (combined strings and interpolations).  This part position applies to all templates with the same tuple of strings.

Note that the purpose of the "unified indexing" (all this `2*len(t.strings) - 1` or `index // 2` madness) is that it allows for exact storage of the part location and also has less complicated usage and more direct iteration.  This is especially true when starting at a part and ending at a part compared to storing and trying to iterate from a `s_index` or an `i_index`.

#### Source Position and Info

The translation from line position to part position is performed for all nodes during parsing and then stored with that tnode.  For tags (elements and components) more info is wanted.  This extra source info is stored in a lookup to avoid overloading the cache and core apis.  A new `TTree` structure is used to store the `root: TNode` and the lookup packed as `sinfos`.  This keeps the core `TNode` subclasses simple as they only have one extra field: `source_pos: PartPosition`.  This assumes that if a node needs extra source info then its source position is unique within that template which seems sensible for now.

## Next Steps

Assuming we don't hit any brick wall blockers we'd keep going along until we get to semi-functioning exception handling:

- part 4: add `TemplateRef` slicing
- part 5: add `SourceReader` and printable repr of `Template`s
- part 6: parser exceptions and handling
- part 7: processor exceptions and handling
