### PR TITLE
Allow extra component params to pass through via `kwargs` as-is.

### DIFF
--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -432,10 +432,7 @@ def _prep_component_kwargs(
     # Add all supported attributes
     for attr_name, attr_value in attrs.items():
         snake_name = _kebab_to_snake(attr_name)
-        if snake_name in callable_info.named_params and (
-            # Don't use a coerced snake name if there is another snake attr available.
-            snake_name == attr_name or snake_name not in attrs
-        ):
+        if snake_name in callable_info.named_params:
             if snake_name in kwargs:
                 raise ValueError(
                     f"Ambiguous attribute {attr_name}: Two attributes resolved to the same named param {snake_name}."

--- a/tdom/processor.py
+++ b/tdom/processor.py
@@ -432,10 +432,19 @@ def _prep_component_kwargs(
     # Add all supported attributes
     for attr_name, attr_value in attrs.items():
         snake_name = _kebab_to_snake(attr_name)
-        if snake_name in callable_info.named_params or callable_info.kwargs:
+        if snake_name in callable_info.named_params and (
+            # Don't use a coerced snake name if there is another snake attr available.
+            snake_name == attr_name or snake_name not in attrs
+        ):
+            if snake_name in kwargs:
+                raise ValueError(
+                    f"Ambiguous attribute {attr_name}: Two attributes resolved to the same named param {snake_name}."
+                )
             kwargs[snake_name] = attr_value
+        elif callable_info.kwargs:
+            kwargs[attr_name] = attr_value  # Retain original attribute name
         else:
-            raise ValueError(f"Unexpected attribute {snake_name}.")
+            raise ValueError(f"Unexpected attribute {attr_name}.")
 
     if "children" in kwargs:
         raise ValueError("The children attribute is reserved for component children.")

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -1570,32 +1570,19 @@ class TestPrepComponentKwargs:
         }
 
     @pytest.mark.parametrize(
-        "attrs", [(("mw-em", 20), ("mw_em", 10)), (("mw_em", 20), ("mw-em", 10))]
+        "attrs",
+        [
+            (
+                ("prefix_attr_value", 10),
+                ("prefix_attr-value", 20),
+            ),  # exact and not exact match
+            (
+                ("prefix-attr_value", 10),
+                ("prefix_attr-value", 20),
+            ),  # both not exact match
+        ],
     )
-    def test_to_snake_collision_no_kwargs(self, attrs):
-        def Wrapper(mw_em):
-            pass
-
-        callable_info = get_callable_info(Wrapper)
-        with pytest.raises(ValueError, match="Unexpected attribute mw-em"):
-            _ = prep_component_kwargs(callable_info, dict(attrs), children=t"")
-
-    @pytest.mark.parametrize(
-        "attrs", [(("mw-em", 20), ("mw_em", 10)), (("mw_em", 10), ("mw-em", 20))]
-    )
-    def test_to_snake_collision_kwargs(self, attrs):
-        def Wrapper(mw_em, **kwargs):
-            pass
-
-        callable_info = get_callable_info(Wrapper)
-        assert prep_component_kwargs(callable_info, dict(attrs), children=t"") == {
-            "mw_em": 10,
-            "mw-em": 20,
-        }, (
-            "Kebab attrs should go into kwargs if there is an exact snake attr available."
-        )
-
-    def test_to_snake_ambiguous_collision(self):
+    def test_to_snake_ambiguous_collision(self, attrs):
         def Wrapper(prefix_attr_value, **kwargs):
             pass
 
@@ -1603,7 +1590,7 @@ class TestPrepComponentKwargs:
         with pytest.raises(ValueError, match="Ambiguous attribute "):
             _ = prep_component_kwargs(
                 callable_info,
-                {"prefix-attr_value": 10, "prefix_attr-value": 20},
+                dict(attrs),
                 children=t"",
             )
 

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -1569,6 +1569,20 @@ class TestPrepComponentKwargs:
             "mw_em": 20
         }
 
+    def test_to_snake_pass_through(self):
+        def Wrapper(mw_em, **kwargs):
+            pass
+
+        callable_info = get_callable_info(Wrapper)
+        assert prep_component_kwargs(
+            callable_info,
+            {"mw-em": 20, "hx-on:click": "alert('Clicked!')"},
+            children=t"",
+        ) == {
+            "mw_em": 20,  # mangled, passed as named param
+            "hx-on:click": "alert('Clicked!')",  # not mangled, will go in kwargs
+        }
+
     @pytest.mark.parametrize(
         "attrs",
         [

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -1560,6 +1560,53 @@ class TestPrepComponentKwargs:
                 callable_info, {"children": t""}, children=t"<span></span>"
             )
 
+    def test_to_snake(self):
+        def Wrapper(mw_em, **kwargs):
+            pass
+
+        callable_info = get_callable_info(Wrapper)
+        assert prep_component_kwargs(callable_info, {"mw-em": 20}, children=t"") == {
+            "mw_em": 20
+        }
+
+    @pytest.mark.parametrize(
+        "attrs", [(("mw-em", 20), ("mw_em", 10)), (("mw_em", 20), ("mw-em", 10))]
+    )
+    def test_to_snake_collision_no_kwargs(self, attrs):
+        def Wrapper(mw_em):
+            pass
+
+        callable_info = get_callable_info(Wrapper)
+        with pytest.raises(ValueError, match="Unexpected attribute mw-em"):
+            _ = prep_component_kwargs(callable_info, dict(attrs), children=t"")
+
+    @pytest.mark.parametrize(
+        "attrs", [(("mw-em", 20), ("mw_em", 10)), (("mw_em", 10), ("mw-em", 20))]
+    )
+    def test_to_snake_collision_kwargs(self, attrs):
+        def Wrapper(mw_em, **kwargs):
+            pass
+
+        callable_info = get_callable_info(Wrapper)
+        assert prep_component_kwargs(callable_info, dict(attrs), children=t"") == {
+            "mw_em": 10,
+            "mw-em": 20,
+        }, (
+            "Kebab attrs should go into kwargs if there is an exact snake attr available."
+        )
+
+    def test_to_snake_ambiguous_collision(self):
+        def Wrapper(prefix_attr_value, **kwargs):
+            pass
+
+        callable_info = get_callable_info(Wrapper)
+        with pytest.raises(ValueError, match="Ambiguous attribute "):
+            _ = prep_component_kwargs(
+                callable_info,
+                {"prefix-attr_value": 10, "prefix_attr-value": 20},
+                children=t"",
+            )
+
 
 class TestFunctionComponent:
     @staticmethod


### PR DESCRIPTION
Potential fix for #156 

Instead of trying to handle the various different situations where a collision occurs an exception is raised.  The snake-ifying of the params is already an ergonomic feature and I think cases where the names collide would likely be a mistake and an exception aligns with those same ergonomics.
