### PR TITLE
Unify docstring syntax; enforce with ruff.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-extend-select = ["ICN"]
+extend-select = ["D210", "D300", "ICN"]
 preview = true
 
 [tool.ruff.lint.flake8-import-conventions]

--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -46,11 +46,11 @@ class OpenTagSourceInfo:
     """
 
     starttag_ref: TemplateRef
-    " Entire starttag as parsed except placeholders are replaced by references. "
+    """Entire starttag as parsed except placeholders are replaced by references."""
     startend: bool
-    " Was parsed as startend tag, ie. <tag />. "
+    """Was parsed as startend tag, ie. <tag />."""
     starttag_pos: PartPosition
-    " Template part position of the starttag. "
+    """Template part position of the starttag."""
 
     def close(self, endtag_pos: PartPosition | None = None) -> TagSourceInfo:
         return TagSourceInfo(
@@ -124,10 +124,10 @@ class SourceTracker:
     placeholders: PlaceholderState
 
     parser_pos_translator: ParserPositionTranslator
-    "Translator from parser position to template part position. "
+    """Translator from parser position to template part position."""
 
     index: int = -1
-    " Unified template index that moves over interpolations and strings. "
+    """Unified template index that moves over interpolations and strings."""
 
     def __iter__(self):
         #
@@ -196,7 +196,7 @@ class TemplateParser(HTMLParser):
     source: SourceTracker | None
 
     sinfo_table: dict[PartPosition, TagSourceInfo]
-    " Tags with more source info than just a position are tracked in this mapping. "
+    """Tags with more source info than just a position are tracked in this mapping."""
 
     def __init__(self, *, convert_charrefs: bool = True):
         # This calls HTMLParser.reset() which we override to set up our state.
@@ -227,7 +227,7 @@ class TemplateParser(HTMLParser):
         return LinePosition(line=line, offset=offset)
 
     def get_source_pos(self, parser_pos: LinePosition | None = None) -> PartPosition:
-        "Translate the parser position into a part position in the source template."
+        """Translate the parser position into a part position in the source template."""
         source = self.get_source()
         return source.translate_parser_pos(
             self.get_parser_pos() if parser_pos is None else parser_pos

--- a/tdom/parser_utils_test.py
+++ b/tdom/parser_utils_test.py
@@ -17,7 +17,7 @@ def ph_config():
 
 
 def make_ppt(template: Template, config: PlaceholderConfig) -> ParserPositionTranslator:
-    "Just a shorthand function."
+    """Just a shorthand function."""
     return make_parser_pos_translator(template=template, config=config)
 
 

--- a/tdom/source.py
+++ b/tdom/source.py
@@ -3,9 +3,9 @@ from dataclasses import dataclass
 
 @dataclass(slots=True, frozen=True)
 class LinePosition:
-    "A immutable position in a block of source code."
+    """A immutable position in a block of source code."""
 
     line: int = 1
-    " Line of code, starts at 1. "
+    """Line of code, starts at 1."""
     offset: int = 0
-    " Offset from the start of the line, starts at 0. "
+    """Offset from the start of the line, starts at 0."""

--- a/tdom/template_utils.py
+++ b/tdom/template_utils.py
@@ -111,10 +111,10 @@ class PartPosition:
     """
 
     index: int
-    " Index of the template parts, translate for strings/interpolations. "
+    """Index of the template parts, translate for strings/interpolations."""
 
     offset: int = 0
-    " Offset from the start of the template part. "
+    """Offset from the start of the template part."""
 
 
 def validate_part_position(part_pos: PartPosition) -> None:

--- a/tdom/tnodes.py
+++ b/tdom/tnodes.py
@@ -118,13 +118,13 @@ class TagSourceInfo:
     """
 
     starttag_ref: TemplateRef
-    " Entire starttag as parsed except placeholders are replaced by references. "
+    """Entire starttag as parsed except placeholders are replaced by references."""
     startend: bool
-    " Was parsed as startend tag, ie. <tag />. "
+    """Was parsed as startend tag, ie. <tag />."""
     starttag_pos: PartPosition
-    " Template part position of the starttag, ie. <tag> or <tag />. "
+    """Template part position of the starttag, ie. <tag> or <tag />."""
     endtag_pos: PartPosition | None = None
-    " Template part position of the endtag, ie. </tag>. "
+    """Template part position of the endtag, ie. </tag>."""
 
 
 @dataclass(slots=True, frozen=True)

--- a/tdom/utils.py
+++ b/tdom/utils.py
@@ -3,7 +3,7 @@ from string.templatelib import Template
 
 
 class LastUpdatedOrderedDict(OrderedDict):
-    "Store items in the order the keys were last updated."
+    """Store items in the order the keys were last updated."""
 
     def __setitem__(self, key, value):
         super().__setitem__(key, value)


### PR DESCRIPTION
We'll use `"""docstring"""` for single-line strings, including after attributes, and:

```python
def foo():
    """
    Here's a long docstring
    
    Maybe very long
    """
```

for multiline. Enabled some `ruff` selectors to enforce this to the extent that `ruff` is willing to do so.