### PR TITLE
Simplify `PartPosition`

### DIFF
--- a/tdom/parser_test.py
+++ b/tdom/parser_test.py
@@ -35,8 +35,8 @@ def literal_template_span(template: Template, text: str) -> TemplateSpan:
     assert len(matches) == 1
     string_index, offset = matches[0]
     return TemplateSpan(
-        start=PartPosition(2 * string_index, offset),
-        stop=PartPosition(2 * string_index, offset + len(text)),
+        start=PartPosition(string_index, offset),
+        stop=PartPosition(string_index, offset + len(text)),
     )
 
 
@@ -437,7 +437,7 @@ def test_component_element_with_closing_tag():
     assert node == TComponent(
         start_i_index=0,
         end_i_index=1,
-        children_span=TemplateSpan(PartPosition(2, 1), PartPosition(2, 1)),
+        children_span=TemplateSpan(PartPosition(1, 1), PartPosition(1, 1)),
     )
 
 
@@ -452,7 +452,7 @@ def test_component_element_special_case_mismatched_closing_tag_still_parses():
     assert node == TComponent(
         start_i_index=0,
         end_i_index=1,
-        children_span=TemplateSpan(PartPosition(2, 1), PartPosition(2, 1)),
+        children_span=TemplateSpan(PartPosition(1, 1), PartPosition(1, 1)),
     )
 
 
@@ -585,7 +585,7 @@ class TestComponentChildrenSpan:
         assert node == TComponent(
             start_i_index=0,
             end_i_index=1,
-            children_span=TemplateSpan(PartPosition(2, 1), PartPosition(2, 1)),
+            children_span=TemplateSpan(PartPosition(1, 1), PartPosition(1, 1)),
         )
 
     def test_extract_startend(self, Component):
@@ -685,7 +685,7 @@ class TestSourcePos:
         ("t", "part_pos"),
         (
             (t"ABC<div></div>", PartPosition(0, offset=len("ABC"))),
-            (t"{' '}<div></div>", PartPosition(2, offset=0)),
+            (t"{' '}<div></div>", PartPosition(1, offset=0)),
         ),
     )
     def test_el(self, t: Template, part_pos: PartPosition):
@@ -698,7 +698,7 @@ class TestSourcePos:
         ("t", "part_pos"),
         (
             (t"<div></div>ABC", PartPosition(0, offset=len("<div></div>"))),
-            (t"<div>{' '}</div>ABC", PartPosition(2, offset=len("</div>"))),
+            (t"<div>{' '}</div>ABC", PartPosition(1, offset=len("</div>"))),
         ),
     )
     def test_text(self, t: Template, part_pos: PartPosition):
@@ -711,7 +711,7 @@ class TestSourcePos:
         ("t", "part_pos"),
         (
             (t"  <!doctype html>", PartPosition(0, offset=2)),
-            (t"{' '}<!doctype html>", PartPosition(2, 0)),
+            (t"{' '}<!doctype html>", PartPosition(1, 0)),
         ),
     )
     def test_doctype(self, t: Template, part_pos: PartPosition):
@@ -724,7 +724,7 @@ class TestSourcePos:
         ("t", "part_pos"),
         (
             (t"  <!--comment-->", PartPosition(0, offset=2)),
-            (t"<div>{'ABC'}</div><!--comment-->", PartPosition(2, len("</div>"))),
+            (t"<div>{'ABC'}</div><!--comment-->", PartPosition(1, len("</div>"))),
         ),
     )
     def test_comment(self, t: Template, part_pos: PartPosition):
@@ -739,7 +739,7 @@ class TestSourcePos:
 
         for t, part_pos in (
             (t"  <{Comp} />", PartPosition(0, offset=len("  "))),
-            (t"  {'ABC'}DEF<{Comp} />", PartPosition(2, offset=len("DEF"))),
+            (t"  {'ABC'}DEF<{Comp} />", PartPosition(1, offset=len("DEF"))),
         ):
             root = parse_root(t)
             assert isinstance(root, TFragment)
@@ -805,9 +805,9 @@ class TestSourceInfo:
         assert sinfo.startend == False
         assert sinfo.starttag_pos == PartPosition(
             0, 0
-        ) and sinfo.endtag_pos == PartPosition(2, len(">"))
+        ) and sinfo.endtag_pos == PartPosition(1, len(">"))
         assert sinfo.starttag_span == TemplateSpan(
-            PartPosition(0, 0), PartPosition(2, len(">"))
+            PartPosition(0, 0), PartPosition(1, len(">"))
         )
 
     def test_component_self_closed(self):
@@ -827,7 +827,7 @@ class TestSourceInfo:
         assert sinfo.startend == True
         assert sinfo.starttag_pos == PartPosition(0, 0) and sinfo.endtag_pos is None
         assert sinfo.starttag_span == TemplateSpan(
-            PartPosition(0, 0), PartPosition(2, len(" />"))
+            PartPosition(0, 0), PartPosition(1, len(" />"))
         )
 
     def test_multiline_component_spans(self):

--- a/tdom/parser_utils.py
+++ b/tdom/parser_utils.py
@@ -1,3 +1,4 @@
+import typing as t
 from bisect import bisect_left
 from dataclasses import dataclass
 from string.templatelib import Template
@@ -11,45 +12,40 @@ type AbsolutePosition = int
 """Absolute position in the placeholder-expanded template source, starting at 0."""
 
 
-def precompute_line_start_positions(source_text: str) -> tuple[AbsolutePosition, ...]:
-    """
-    Return the absolute positions where each line in the parser input starts.
-
-    The first line always starts at zero. A trailing newline therefore produces
-    one final line start whose absolute position is also the length of the input.
-    """
-    return (0, *(index + 1 for index, char in enumerate(source_text) if char == "\n"))
-
-
 def make_parser_pos_translator(
     template: Template, config: PlaceholderConfig
 ) -> ParserPositionTranslator:
     """
     Configure and return a `ParserPositionTranslator`.
 
-    We precompute a few things to make the translator's job easier.
+    Precompute line and string positions to make translation efficient.
     """
 
-    source_text_parts: list[str] = []
+    line_start_positions: list[AbsolutePosition] = [0]
     string_start_positions: list[AbsolutePosition] = []
     string_end_positions: list[AbsolutePosition] = []
     source_pos: AbsolutePosition = 0
 
+    def line_starts(string: str) -> t.Iterator[AbsolutePosition]:
+        return (
+            source_pos + offset + 1
+            for offset, char in enumerate(string)
+            if char == "\n"
+        )
+
     for s_index, string in enumerate(template.strings):
         string_start_positions.append(source_pos)
-        source_text_parts.append(string)
+        line_start_positions.extend(line_starts(string))
         source_pos += len(string)
         string_end_positions.append(source_pos)
 
         if s_index < len(template.interpolations):
             placeholder = config.make_placeholder(s_index)
-            source_text_parts.append(placeholder)
+            line_start_positions.extend(line_starts(placeholder))
             source_pos += len(placeholder)
 
-    source_text = "".join(source_text_parts)
-
     return ParserPositionTranslator(
-        line_start_positions=precompute_line_start_positions(source_text),
+        line_start_positions=tuple(line_start_positions),
         string_start_positions=tuple(string_start_positions),
         string_end_positions=tuple(string_end_positions),
     )

--- a/tdom/parser_utils.py
+++ b/tdom/parser_utils.py
@@ -1,6 +1,5 @@
 from bisect import bisect_left
 from dataclasses import dataclass
-from itertools import accumulate
 from string.templatelib import Template
 
 from .placeholders import PlaceholderConfig
@@ -31,17 +30,28 @@ def make_parser_pos_translator(
     We precompute a few things to make the translator's job easier.
     """
 
-    source_text_parts = tuple(
-        template.strings[index // 2]
-        if index % 2 == 0
-        else config.make_placeholder((index - 1) // 2)
-        for index in range(2 * len(template.strings) - 1)
-    )
+    source_text_parts: list[str] = []
+    string_start_positions: list[AbsolutePosition] = []
+    string_end_positions: list[AbsolutePosition] = []
+    source_pos: AbsolutePosition = 0
+
+    for s_index, string in enumerate(template.strings):
+        string_start_positions.append(source_pos)
+        source_text_parts.append(string)
+        source_pos += len(string)
+        string_end_positions.append(source_pos)
+
+        if s_index < len(template.interpolations):
+            placeholder = config.make_placeholder(s_index)
+            source_text_parts.append(placeholder)
+            source_pos += len(placeholder)
+
     source_text = "".join(source_text_parts)
 
     return ParserPositionTranslator(
         line_start_positions=precompute_line_start_positions(source_text),
-        part_end_positions=tuple(accumulate(map(len, source_text_parts))),
+        string_start_positions=tuple(string_start_positions),
+        string_end_positions=tuple(string_end_positions),
     )
 
 
@@ -50,8 +60,11 @@ class ParserPositionTranslator:
     line_start_positions: tuple[AbsolutePosition, ...]
     """Absolute positions where lines in the parser input start."""
 
-    part_end_positions: tuple[AbsolutePosition, ...]
-    """Absolute positions where placeholder-expanded template parts end."""
+    string_start_positions: tuple[AbsolutePosition, ...]
+    """Absolute positions where static strings start in the parser input."""
+
+    string_end_positions: tuple[AbsolutePosition, ...]
+    """Absolute positions where static strings end in the parser input."""
 
     def line_pos_to_abs_pos(
         self,
@@ -77,7 +90,7 @@ class ParserPositionTranslator:
         line_end = (
             self.line_start_positions[line] - 1
             if line < line_count
-            else self.part_end_positions[-1]
+            else self.string_end_positions[-1]
         )
         line_length = line_end - line_start
         if offset > line_length:
@@ -95,27 +108,19 @@ class ParserPositionTranslator:
         Positions inside placeholders cannot be translated because interpolations
         are atomic.
         """
-        source_length = self.part_end_positions[-1]
+        source_length = self.string_end_positions[-1]
         if not 0 <= abs_pos <= source_length:
             raise ValueError(
                 f"Absolute position falls outside the input: {abs_pos} not in [0, {source_length}]"
             )
 
-        last_part_index = len(self.part_end_positions) - 1
-        if abs_pos == source_length:
-            final_part_start = (
-                self.part_end_positions[last_part_index - 1] if last_part_index else 0
+        s_index = bisect_left(self.string_end_positions, abs_pos)
+        string_start = self.string_start_positions[s_index]
+        if abs_pos < string_start:
+            raise ValueError(
+                "Positions inside interpolation placeholders are undefined."
             )
-            return PartPosition(last_part_index // 2, source_length - final_part_start)
-
-        part_index = bisect_left(self.part_end_positions, abs_pos)
-        part_start = self.part_end_positions[part_index - 1] if part_index else 0
-
-        if part_index % 2 == 0:
-            return PartPosition(part_index // 2, abs_pos - part_start)
-        if abs_pos == self.part_end_positions[part_index]:
-            return PartPosition(part_index // 2 + 1, 0)
-        raise ValueError("Positions inside interpolation placeholders are undefined.")
+        return PartPosition(s_index, abs_pos - string_start)
 
     def translate(self, parser_pos: LinePosition) -> PartPosition:
         """

--- a/tdom/parser_utils.py
+++ b/tdom/parser_utils.py
@@ -90,9 +90,10 @@ class ParserPositionTranslator:
         """
         Translate an absolute position into a template part position.
 
-        A position exactly between parts belongs to the following part. EOF is the
-        exception: a template always ends with a string part, and EOF belongs to the
-        end of that final string.
+        Positions at a placeholder's start and end are represented by the end of
+        its preceding string and the start of its following string, respectively.
+        Positions inside placeholders cannot be translated because interpolations
+        are atomic.
         """
         source_length = self.part_end_positions[-1]
         if not 0 <= abs_pos <= source_length:
@@ -100,18 +101,21 @@ class ParserPositionTranslator:
                 f"Absolute position falls outside the input: {abs_pos} not in [0, {source_length}]"
             )
 
-        last_index = len(self.part_end_positions) - 1
+        last_part_index = len(self.part_end_positions) - 1
         if abs_pos == source_length:
             final_part_start = (
-                self.part_end_positions[last_index - 1] if last_index else 0
+                self.part_end_positions[last_part_index - 1] if last_part_index else 0
             )
-            return PartPosition(last_index, source_length - final_part_start)
+            return PartPosition(last_part_index // 2, source_length - final_part_start)
 
-        index = bisect_left(self.part_end_positions, abs_pos)
-        part_start = self.part_end_positions[index - 1] if index else 0
-        if abs_pos == self.part_end_positions[index]:
-            return PartPosition(index + 1, 0)
-        return PartPosition(index, abs_pos - part_start)
+        part_index = bisect_left(self.part_end_positions, abs_pos)
+        part_start = self.part_end_positions[part_index - 1] if part_index else 0
+
+        if part_index % 2 == 0:
+            return PartPosition(part_index // 2, abs_pos - part_start)
+        if abs_pos == self.part_end_positions[part_index]:
+            return PartPosition(part_index // 2 + 1, 0)
+        raise ValueError("Positions inside interpolation placeholders are undefined.")
 
     def translate(self, parser_pos: LinePosition) -> PartPosition:
         """
@@ -123,9 +127,7 @@ class ParserPositionTranslator:
             injected for `Interpolation`s.
 
         return:
-            A position in a coordinate system that uses a unified index into
-            the parts of the `Template`.  For interpolations the offset must be
-            `0` but the offset can be a non-zero number for string parts.
+            A position relative to one of the `Template`'s static strings.
         """
         abs_pos = self.line_pos_to_abs_pos(parser_pos)
         return self.abs_pos_to_part_pos(abs_pos)

--- a/tdom/parser_utils_test.py
+++ b/tdom/parser_utils_test.py
@@ -36,9 +36,9 @@ class TestParserPositionTranslator:
         placeholder_length = len(ph_config.make_placeholder(0))
 
         assert ppt.abs_pos_to_part_pos(0) == PartPosition(0, 0)
-        assert ppt.abs_pos_to_part_pos(1) == PartPosition(1, 0)
-        assert ppt.abs_pos_to_part_pos(1 + placeholder_length) == PartPosition(2, 0)
-        assert ppt.abs_pos_to_part_pos(2 + placeholder_length) == PartPosition(2, 1)
+        assert ppt.abs_pos_to_part_pos(1) == PartPosition(0, 1)
+        assert ppt.abs_pos_to_part_pos(1 + placeholder_length) == PartPosition(1, 0)
+        assert ppt.abs_pos_to_part_pos(2 + placeholder_length) == PartPosition(1, 1)
 
         with pytest.raises(ValueError, match="Absolute position falls outside"):
             ppt.abs_pos_to_part_pos(-1)
@@ -54,7 +54,7 @@ class TestParserPositionTranslator:
             len("<") + placeholder_length + len("\n x>"),
         ) == TemplateSpan(
             start=PartPosition(0, len("before\n  ")),
-            stop=PartPosition(2, len("\n x>")),
+            stop=PartPosition(1, len("\n x>")),
         )
 
         with pytest.raises(ValueError, match="Parser span length must be positive"):
@@ -63,41 +63,39 @@ class TestParserPositionTranslator:
     def test_case_nontailing_string_ends_with_newline(self, ph_config):
         ppt = make_ppt(t"a\n{0}b", ph_config)
         assert ppt.translate(LinePosition(line=2, offset=0)) == PartPosition(
-            index=1, offset=0
-        ), """This could also be considered PartPosition(index=1, offset=0)
-        but either way should work. """
+            s_index=0, offset=len("a\n")
+        ), "The placeholder starts at the end of its preceding string."
         assert ppt.translate(
             LinePosition(line=2, offset=len(ph_config.make_placeholder(0)))
         ) == PartPosition(
-            index=2, offset=0
+            s_index=1, offset=0
         ), """This must be the start of the following string because we can't
-        know the offset of the actual interpolation content. Ie. It cannot be
-        index=1 with "some" offset."""
+        know the offset of the actual interpolation content."""
 
     def test_case_tailing_string_starts_with_newline(self, ph_config):
         ppt = make_ppt(t"a{0}\nb", ph_config)
         assert ppt.translate(LinePosition(line=2, offset=0)) == PartPosition(
-            index=2, offset=1
+            s_index=1, offset=1
         ), "line 2 should be inside the tailing string"
         assert ppt.translate(
             LinePosition(line=1, offset=1 + len(ph_config.make_placeholder(0)))
-        ) == PartPosition(index=2, offset=0), (
+        ) == PartPosition(s_index=1, offset=0), (
             "end of line 1 should be inside the tailing string?"
         )
 
     def test_case_interpolation_without_lines(self, ph_config):
         ppt = make_ppt(t"a{0}b", ph_config)
         assert ppt.translate(LinePosition(line=1, offset=1)) == PartPosition(
-            index=1, offset=0
-        ), "end of the head string is the start of the interpolation"
+            s_index=0, offset=1
+        ), "the interpolation starts at the end of the preceding string"
         assert ppt.translate(
             LinePosition(line=1, offset=1 + len(ph_config.make_placeholder(0)))
-        ) == PartPosition(index=2, offset=0), (
+        ) == PartPosition(s_index=1, offset=0), (
             "the end of the interpolation is the start of the tailing string"
         )
         assert ppt.translate(
             LinePosition(line=1, offset=1 + len(ph_config.make_placeholder(0)) + 1)
-        ) == PartPosition(index=2, offset=1), (
+        ) == PartPosition(s_index=1, offset=1), (
             "the end of the tailing string remains the end."
         )
 
@@ -105,33 +103,33 @@ class TestParserPositionTranslator:
         ppt = make_ppt(t"{0}{1}", ph_config)
         placeholder_length = len(ph_config.make_placeholder(0))
 
-        assert ppt.translate(LinePosition(1, 0)) == PartPosition(1, 0)
-        assert ppt.translate(LinePosition(1, placeholder_length)) == PartPosition(2, 0)
+        assert ppt.translate(LinePosition(1, 0)) == PartPosition(0, 0)
+        assert ppt.translate(LinePosition(1, placeholder_length)) == PartPosition(1, 0)
         assert ppt.translate(LinePosition(1, 2 * placeholder_length)) == PartPosition(
-            4, 0
+            2, 0
         )
 
     def test_offset_without_line(self, ph_config):
         ppt = make_ppt(t"a*", ph_config)
         assert ppt.translate(LinePosition(line=1, offset=1)) == PartPosition(
-            index=0, offset=1
+            s_index=0, offset=1
         ), "the offset matches up without lines"
         assert ppt.translate(LinePosition(line=1, offset=2)) == PartPosition(
-            index=0, offset=2
+            s_index=0, offset=2
         ), "end of line is end of string"
         with pytest.raises(ValueError, match="Offset exceeds reachable"):
             # only 0, 1 and 2 are valid offsets for line 1
             _ = ppt.translate(LinePosition(line=1, offset=3)) == PartPosition(
-                index=0, offset=3
+                s_index=0, offset=3
             )
 
     def test_offset_with_line(self, ph_config):
         ppt = make_ppt(t"ab\n*", ph_config)
         assert ppt.translate(LinePosition(line=2, offset=0)) == PartPosition(
-            index=0, offset=3
+            s_index=0, offset=3
         ), "2nd line starts at offset in the head string"
         assert ppt.translate(LinePosition(line=1, offset=2)) == PartPosition(
-            index=0, offset=2
+            s_index=0, offset=2
         ), "end of 1st line is offset to NL"
         with pytest.raises(ValueError, match="Offset exceeds reachable"):
             # only 0, 1 and 2 are valid offsets for line 1
@@ -141,16 +139,16 @@ class TestParserPositionTranslator:
         ppt = make_ppt(t"a\nb{0}cd\ne{1}\nfe", ph_config)
         assert ppt.translate(
             LinePosition(line=2, offset=1 + len(ph_config.make_placeholder(0)) + 2)
-        ) == PartPosition(index=2, offset=2)
+        ) == PartPosition(s_index=1, offset=2)
 
     def test_empty_strings(self, ph_config):
         ppt = make_ppt(t"{0}", ph_config)
         assert ppt.translate(LinePosition(line=1, offset=0)) == PartPosition(
-            index=1, offset=0
-        ), "start of head string is start of interpolation"
+            s_index=0, offset=0
+        ), "the interpolation starts at the end of the empty preceding string"
         assert ppt.translate(
             LinePosition(line=1, offset=len(ph_config.make_placeholder(0)))
-        ) == PartPosition(index=2, offset=0), (
+        ) == PartPosition(s_index=1, offset=0), (
             "end of interpolation is start of tail string"
         )
         with pytest.raises(ValueError, match="Offset exceeds reachable"):
@@ -162,7 +160,7 @@ class TestParserPositionTranslator:
     def test_empty_string(self, ph_config):
         ppt = make_ppt(t"", ph_config)
         assert ppt.translate(LinePosition(line=1, offset=0)) == PartPosition(
-            index=0, offset=0
+            s_index=0, offset=0
         )
         with pytest.raises(ValueError, match="Offset exceeds reachable"):
             # Cannot go past end of the template.
@@ -171,13 +169,13 @@ class TestParserPositionTranslator:
     def test_empty_line(self, ph_config):
         ppt = make_ppt(t"\n", ph_config)
         assert ppt.translate(LinePosition(line=1, offset=0)) == PartPosition(
-            index=0, offset=0
+            s_index=0, offset=0
         )
         with pytest.raises(ValueError, match="Offset exceeds reachable"):
             # line 1 is empty, cannot offset anything
             _ = ppt.translate(LinePosition(line=1, offset=1))
         assert ppt.translate(LinePosition(line=2, offset=0)) == PartPosition(
-            index=0, offset=1
+            s_index=0, offset=1
         ), "To skip over empty line just skip over newline"
         with pytest.raises(ValueError, match="Offset exceeds reachable"):
             # line 2 is empty, cannot offset anything
@@ -204,12 +202,12 @@ class TestParserPositionTranslator:
 
         with pytest.raises(
             ValueError,
-            match="Interpolation part positions must always have offset 0.",
+            match="Positions inside interpolation placeholders are undefined.",
         ):
             _ = ppt.translate(LinePosition(line=2, offset=1))
         with pytest.raises(
             ValueError,
-            match="Interpolation part positions must always have offset 0.",
+            match="Positions inside interpolation placeholders are undefined.",
         ):
             _ = ppt.translate(
                 LinePosition(line=2, offset=len(ph_config.make_placeholder(0)) - 1)

--- a/tdom/template_utils.py
+++ b/tdom/template_utils.py
@@ -107,66 +107,44 @@ class TemplateRef:
 @dataclass(slots=True, frozen=True, order=True)
 class PartPosition:
     """
-    A unified template part position.
+    A position relative to one of a template's static strings.
 
-    Translate indexes into strings by multiplying by 2.
-    ie. 0->0, 1->2, 2->4, etc.
-    Reverse by dividing by 2.
-
-    Translate indexes into interpolations by multiplying by 2 and then adding 1.
-    ie. 0->1, 1->3, 2->5, etc.
-    Reverse by subtracting 1 and dividing by 2.
-
-    Using unified indexes allows for simpler iteration as well as starting
-    or stopping at either type of part more seamlessly.
+    The end of a string is immediately before its following interpolation, and
+    the start of the next string is immediately after that interpolation. Thus a
+    span between those positions contains exactly that atomic interpolation.
     """
 
-    index: int
-    """Index of the template parts, translate for strings/interpolations."""
+    s_index: int
+    """Index of the static string relative to which the position is measured."""
 
     offset: int = 0
-    """Offset from the start of the template part."""
-
-    @property
-    def is_string(self) -> bool:
-        """Return True if this position is within a string part."""
-        return self.index % 2 == 0
-
-    @property
-    def is_interpolation(self) -> bool:
-        """Return True if this position is at an interpolation part."""
-        return not self.is_string
+    """Offset from the start of the static string."""
 
     def __post_init__(self) -> None:
-        """Validate invariants shared by every template part position."""
-        if self.index < 0:
-            raise ValueError("Index must always be positive or zero.")
+        """Validate invariants independent of a particular template."""
+        if self.s_index < 0:
+            raise ValueError("String index must always be positive or zero.")
         if self.offset < 0:
             raise ValueError("Offset must always be positive or zero.")
-        if self.is_interpolation and self.offset != 0:
-            # Interpolations are indivisible, so their only position is the start.
-            raise ValueError("Interpolation part positions must always have offset 0.")
 
     def validate(self, source: Template) -> None:
         """Raise if this position falls outside the source template."""
-        part_count = 2 * len(source.strings) - 1
-        if self.index >= part_count:
+        if self.s_index >= len(source.strings):
             raise ValueError(
-                "PartPosition index falls outside the template: "
-                f"{self.index} >= {part_count}."
+                "PartPosition string index falls outside the template: "
+                f"{self.s_index} >= {len(source.strings)}."
             )
-        if self.is_string:
-            string = source.strings[self.index // 2]
-            if self.offset > len(string):
-                raise ValueError(
-                    "PartPosition offset falls outside its string: "
-                    f"{self.offset} > {len(string)}."
-                )
+        string = source.strings[self.s_index]
+        if self.offset > len(string):
+            raise ValueError(
+                "PartPosition offset falls outside its string: "
+                f"{self.offset} > {len(string)}."
+            )
 
 
 @dataclass(slots=True, frozen=True)
 class TemplateSpan:
-    """A half-open span in the global part coordinates of a template."""
+    """A half-open span in the static-string coordinates of a template."""
 
     start: PartPosition
     stop: PartPosition
@@ -180,17 +158,12 @@ class TemplateSpan:
         self.start.validate(source)
         self.stop.validate(source)
 
-        first_string = self.start.index // 2
-        last_string = self.stop.index // 2
+        first_string = self.start.s_index
+        last_string = self.stop.s_index
         strings = list(source.strings[first_string : last_string + 1])
 
-        if self.stop.is_string:
-            strings[-1] = strings[-1][: self.stop.offset]
-
-        if self.start.is_string:
-            strings[0] = strings[0][self.start.offset :]
-        else:
-            strings[0] = ""
+        strings[-1] = strings[-1][: self.stop.offset]
+        strings[0] = strings[0][self.start.offset :]
 
         return template_from_parts(
             strings, source.interpolations[first_string:last_string]

--- a/tdom/template_utils_test.py
+++ b/tdom/template_utils_test.py
@@ -139,41 +139,28 @@ def test_template_ref_bind():
 
 
 class TestPartPosition:
-    @pytest.mark.parametrize(
-        ("position", "is_string", "is_interpolation"),
-        (
-            (PartPosition(0), True, False),
-            (PartPosition(1), False, True),
-            (PartPosition(2), True, False),
-        ),
-    )
-    def test_part_type(
-        self,
-        position: PartPosition,
-        is_string: bool,
-        is_interpolation: bool,
-    ) -> None:
-        assert position.is_string is is_string
-        assert position.is_interpolation is is_interpolation
+    def test_is_relative_to_static_string(self) -> None:
+        position = PartPosition(s_index=1, offset=2)
+
+        assert position.s_index == 1
+        assert position.offset == 2
 
     @pytest.mark.parametrize(
-        ("index", "offset", "message"),
+        ("s_index", "offset", "message"),
         (
-            (-1, 0, "Index must always be positive or zero"),
+            (-1, 0, "String index must always be positive or zero"),
             (0, -1, "Offset must always be positive or zero"),
-            (1, 1, "Interpolation part positions must always have offset 0"),
         ),
     )
-    def test_invalid(self, index: int, offset: int, message: str) -> None:
+    def test_invalid(self, s_index: int, offset: int, message: str) -> None:
         with pytest.raises(ValueError, match=message):
-            _ = PartPosition(index, offset)
+            _ = PartPosition(s_index, offset)
 
     @pytest.mark.parametrize(
         ("earlier", "later"),
         (
             (PartPosition(0), PartPosition(0, 1)),
             (PartPosition(0, 1), PartPosition(1)),
-            (PartPosition(1), PartPosition(2)),
         ),
     )
     def test_ordering(self, earlier: PartPosition, later: PartPosition) -> None:
@@ -184,7 +171,7 @@ class TestTemplateSpan:
     @pytest.mark.parametrize(
         ("start", "stop"),
         (
-            (PartPosition(2), PartPosition(0)),
+            (PartPosition(1), PartPosition(0)),
             (PartPosition(0, 2), PartPosition(0, 1)),
         ),
     )
@@ -195,12 +182,12 @@ class TestTemplateSpan:
     @pytest.mark.parametrize(
         "span",
         (
-            TemplateSpan(PartPosition(3), PartPosition(3)),
-            TemplateSpan(PartPosition(0), PartPosition(3)),
+            TemplateSpan(PartPosition(1), PartPosition(1)),
+            TemplateSpan(PartPosition(0), PartPosition(1)),
         ),
     )
     def test_position_outside_template(self, span: TemplateSpan) -> None:
-        with pytest.raises(ValueError, match="PartPosition index"):
+        with pytest.raises(ValueError, match="PartPosition string index"):
             _ = span.extract(t"ABC")
 
     def test_offset_outside_template_string(self) -> None:
@@ -211,7 +198,7 @@ class TestTemplateSpan:
 
     def test_retains_original_interpolation_objects(self) -> None:
         source = t"before {object()} after"
-        span = TemplateSpan(PartPosition(0, 7), PartPosition(2, 0))
+        span = TemplateSpan(PartPosition(0, 7), PartPosition(1, 0))
 
         extracted = span.extract(source)
 
@@ -232,26 +219,31 @@ class TestTemplateSpanExtract:
                 ("><",),
             ),
             (t"<div></div>", PartPosition(0, offset=5), PartPosition(0, offset=5), ()),
-            (t"<div>{0}</div>", None, PartPosition(1, offset=0), ("<div>",)),
-            (t"<div>{0}</div>", PartPosition(1, offset=0), None, (0, "</div>")),
-            (t"<div>{0}</div>", PartPosition(2, offset=0), None, ("</div>",)),
-            (t"<div>{0}</div>", None, PartPosition(2, offset=0), ("<div>", 0)),
+            (t"<div>{0}</div>", None, PartPosition(0, offset=5), ("<div>",)),
             (
                 t"<div>{0}</div>",
+                PartPosition(0, offset=5),
+                None,
+                (0, "</div>"),
+            ),
+            (t"<div>{0}</div>", PartPosition(1, offset=0), None, ("</div>",)),
+            (t"<div>{0}</div>", None, PartPosition(1, offset=0), ("<div>", 0)),
+            (
+                t"<div>{0}</div>",
+                PartPosition(0, offset=5),
                 PartPosition(1, offset=0),
-                PartPosition(2, offset=0),
                 (0,),
             ),
             (
                 t"<div>{0}</div>",
-                PartPosition(1, offset=0),
-                PartPosition(1, offset=0),
+                PartPosition(0, offset=5),
+                PartPosition(0, offset=5),
                 (),
             ),
             (t"", None, PartPosition(0, offset=0), ()),
             (t"", PartPosition(0, offset=0), None, ()),
             (t"", None, None, ()),
-            (t"{0}", None, PartPosition(2, offset=0), (0,)),
+            (t"{0}", None, PartPosition(1, offset=0), (0,)),
             (t"{0}", PartPosition(0, offset=0), None, (0,)),
             (t"{0}", None, None, (0,)),
         ),
@@ -265,7 +257,7 @@ class TestTemplateSpanExtract:
     ) -> None:
         span = TemplateSpan(
             start=start or PartPosition(0),
-            stop=stop or PartPosition(2 * len(t.strings) - 2, len(t.strings[-1])),
+            stop=stop or PartPosition(len(t.strings) - 1, len(t.strings[-1])),
         )
         extracted = span.extract(t)
         parts: list[str | object] = []
@@ -278,8 +270,8 @@ class TestTemplateSpanExtract:
 
     def test_interpolation_interval(self) -> None:
         extracted = TemplateSpan(
-            start=PartPosition(1),
-            stop=PartPosition(2),
+            start=PartPosition(0, len("<div>")),
+            stop=PartPosition(1),
         ).extract(t"<div>{0}</div>")
 
         assert extracted.strings == ("", "")


### PR DESCRIPTION
Instead of `PartPosition.index` representing an index into interleaved strings and interpolations, we now have `PartPosition.s_index` which can only _ever_ represent an index to a Template string. An `offset` of `0` means "just before this string" (and therefore "just after the preceding interpolation, if any"); an `offset` of `len(the_string)` means "just after this string" (and therefore "just before the following interpolation, if any").

This simplifies a bunch of downstream code (see `extract()` and `abs_pos_to_part_pos()` for example) and removes some of the awkwardness around `offset` if the position were previously an interpolation.
