### PR TITLE
Stop introspecting rawdata after Python 3.14.7 internal buffering added.

### DIFF
--- a/tdom/parser.py
+++ b/tdom/parser.py
@@ -504,24 +504,11 @@ class TemplateParser(HTMLParser):
         self.sinfo_table = {}
 
     def close(self) -> None:
-        if self.waiting_for_data():
-            # We apply heuristics here to try to guess why the parser didn't finish.
-            if self.rawdata.count('"') % 2 == 1 or self.rawdata.count("'") % 2 == 1:
-                raise ValueError(
-                    "Parser expects more data, maybe you left an attribute quote unclosed?"
-                )
-            else:
-                raise ValueError(
-                    "Parser expects more data, is the template valid html?"
-                )
+        super().close()
         if self.stack:
             raise ValueError("Invalid HTML structure: unclosed tags remain.")
         if self.source and self.source.has_placeholders():
             raise ValueError("Some placeholders were never resolved.")
-        super().close()
-
-    def waiting_for_data(self):
-        return len(self.rawdata) > 0
 
     # ------------------------------------------
     # Getting the parsed node tree

--- a/tdom/parser_test.py
+++ b/tdom/parser_test.py
@@ -556,22 +556,6 @@ class TestSourceTracker:
         )
 
 
-class TestIncompleteParsing:
-    def test_dangling_quotes(self):
-        with pytest.raises(ValueError, match="Parser expects more data"):
-            _ = parse_root(t"<div a='")
-        with pytest.raises(ValueError, match="Parser expects more data"):
-            _ = parse_root(t'<div a="')
-
-    def test_unfinished_attribute(self):
-        with pytest.raises(ValueError, match="Parser expects more data"):
-            _ = parse_root(t"<div a=")
-
-    def test_placeholder_missing_from_dangling_quote(self):
-        with pytest.raises(ValueError, match="Parser expects more data"):
-            _ = parse_root(t'<div a="{None}')
-
-
 class TestComponentChildrenSpan:
     @pytest.fixture
     def Component(self):

--- a/tdom/processor_test.py
+++ b/tdom/processor_test.py
@@ -2273,3 +2273,9 @@ def test_mathml():
   is not a decimal number.
 </p>"""
     )
+
+
+def test_issue_166():
+    template = t"<button disabled={True}>x</button><button disabled={True}>y</button>"
+    expected = "<button disabled>x</button><button disabled>y</button>"
+    assert html(template) == expected


### PR DESCRIPTION
We were introspecting `rawdata` to try to detect at least this error:

https://html.spec.whatwg.org/multipage/parsing.html#parse-error-eof-in-tag

> eof-in-tag
> 
> This error occurs if the parser encounters the end of the input stream in a start tag or an end tag (e.g., <div id=). Such a tag is ignored.

Especially in the case of a dangling quote: `html(t'<div x="{1}></div>')`.

This PR just cuts all that out and we lose some user experience but drop our dependency on `rawdata`.