### PR TITLE
Support a test matrix of 3.14.6, 3.14.latest, and 3.15rc0+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   ci_tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,16 +4,26 @@ on: [push, pull_request]
 
 jobs:
   ci_tests:
-    name: python
+    name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Keep 3.14.6 to cover HTMLParser behavior before the 3.14.7 change.
+        python-version: ["3.14.6", "3.14", "3.15"]
+    env:
+      # Override the local development pin in .python-version.
+      UV_PYTHON: ${{ matrix.python-version }}
 
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up Python 3.14.6
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v7
         with:
-          python-version: 3.14.6
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+          check-latest: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -11,14 +11,25 @@ permissions:
 
 jobs:
   test_and_build:
+    name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Keep 3.14.6 to cover HTMLParser behavior before the 3.14.7 change.
+        python-version: ["3.14.6", "3.14", "3.15"]
+    env:
+      # Override the local development pin in .python-version.
+      UV_PYTHON: ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up Python 3.14.6
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v7
         with:
-          python-version: 3.14.6
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+          check-latest: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
@@ -51,9 +62,12 @@ jobs:
         run: uv run pytest -v
 
       - name: Build
+        # One pure Python wheel works on every supported Python version.
+        if: matrix.python-version == '3.14'
         run: uv build
 
       - name: Store the distribution packages
+        if: matrix.python-version == '3.14'
         uses: actions/upload-artifact@v7
         with:
           name: python-packages

--- a/justfile
+++ b/justfile
@@ -23,6 +23,19 @@ type_check: type_check_pyright type_check_ty
 test:
     uv run pytest
 
+# Test the CI Python matrix without replacing the development .venv.
+test-matrix:
+    #!/usr/bin/env sh
+    set -eu
+    uv python install --no-bin 3.14.6
+    uv python install --upgrade --no-bin 3.14 3.15
+    result=0
+    # Keep in sync with the CI and PyPI workflow matrices.
+    for version in 3.14.6 3.14 3.15; do
+        uv run --isolated --locked --managed-python --python "$version" pytest -v || result=1
+    done
+    exit "$result"
+
 watch:
     # Watch for changes and run tests.
     uv run ptw tdom/  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
   "Topic :: Text Processing :: Markup :: HTML",
   "Typing :: Typed",


### PR DESCRIPTION
[Python 3.15 is just a few weeks away](https://hugovk.dev/blog/2026/help-test-python-315/).

This updates our matrix to test against:

1. 3.14.latest (currently 3.14.7)
2. 3.14.6 (since 3.14.7 introduced a change to `HTMLParser` that [broke us](https://github.com/t-strings/tdom/issues/166) and shed light on our use of internal implementation details)
3.  3.15 latest RC or release

The matrix runs in CI automatically; you can run it locally with `just test-matrix`. (`just test` continues to only use your local venv)

**Also!**: I've enabled `main` branch protection. I can no longer willy-nilly commit to `main`. Shame on me for ever having done so.
