### PR TITLE
Add basic tools to version bump + release

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -2,7 +2,7 @@ name: Publish Python Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
   workflow_dispatch:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,23 @@
+# Releasing tdom
+
+Use a version-bump PR, then publish a GitHub release after it merges. You need
+`git`, `uv`, `just`, and an authenticated GitHub CLI (`gh auth login`), with
+`origin` pointing to `t-strings/tdom`. Start with a clean working tree.
+
+1. Run `just release-pr 0.1.20` (substitute the version you want). This creates
+   a branch from the latest `origin/main`, updates `pyproject.toml` and
+   `uv.lock`, commits and pushes the change, and opens a PR.
+2. Wait for all three Python CI checks to pass, then merge the PR on GitHub.
+3. Run `just release`. This switches to `main`, pulls the merged changes, tags
+   that version as `v0.1.20`, and publishes a GitHub release with generated
+   notes. The existing publishing workflow tests all three Python versions,
+   builds one wheel and source distribution, and publishes them to PyPI.
+
+`just release` refuses unpublished local commits on `main` and existing local
+tags. Neither command bypasses branch protection. The commands stop on errors;
+if a network operation fails, inspect the output and resume the failed step. For
+example, if the tag was pushed but release creation failed, run
+`gh release create v0.1.20 --verify-tag --generate-notes`.
+
+You can also publish the release through GitHub's web interface using the tag.
+Publishing a saved draft triggers the same PyPI workflow.

--- a/justfile
+++ b/justfile
@@ -56,6 +56,43 @@ build: build_docs build_package
 
 clean: clean_docs clean_package
 
+# Open a version-bump PR from origin/main (requires git, uv, and authenticated gh).
+[positional-arguments]
+release-pr version:
+    #!/usr/bin/env sh
+    set -eu
+    if [ -n "$(git status --porcelain)" ]; then
+        echo "Commit or stash your changes before preparing a release." >&2
+        exit 1
+    fi
+    version=$(uv version "$1" --dry-run --short)
+    git fetch origin main
+    git switch --no-track -c "release/v$version" origin/main
+    uv version "$version" --no-sync
+    git add pyproject.toml uv.lock
+    git commit -m "Bump version to $version"
+    git push -u origin HEAD
+    gh pr create --base main --head "release/v$version" --title "Release v$version" --body "Bump the package version to $version. Publish the GitHub release after this PR passes CI and merges."
+
+# Publish the version on origin/main; the GitHub release starts the PyPI workflow.
+release:
+    #!/usr/bin/env sh
+    set -eu
+    if [ -n "$(git status --porcelain)" ]; then
+        echo "Commit or stash your changes before publishing a release." >&2
+        exit 1
+    fi
+    git switch main
+    git pull --ff-only origin main
+    if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
+        echo "Local main has unpublished commits; release from origin/main only." >&2
+        exit 1
+    fi
+    version=$(uv version --short)
+    git tag "v$version"
+    git push origin "refs/tags/v$version"
+    gh release create "v$version" --verify-tag --generate-notes
+
 reports:
     uv run pytest --cov=tdom --cov-report=xml:reports/coverage.xml --cov-report=term --cov-report=html:reports/coverage --junitxml=reports/pytest.xml --html=reports/pytest.html
 


### PR DESCRIPTION
Now that the `main` branch is protected, all work needs to go through a PR. This adds two `just` tasks to support the process. See [`RELEASING.md`](./RELEASING.md) for details.